### PR TITLE
zmq.py: print error message when the duplicator buffer is full

### DIFF
--- a/mite/zmq.py
+++ b/mite/zmq.py
@@ -46,7 +46,10 @@ class Sender:
         logger.debug("sender connected to address: %s", address)
 
     def send(self, msg):
-        self._socket.send(pack_msg(msg))
+        try:
+            self._socket.send(pack_msg(msg), flags=zmq.NOBLOCK)
+        except zmq.ZMQError:
+            pass  # TODO: what should happen here?
 
 
 class Receiver:


### PR DESCRIPTION
How you can test this change:

start up a mite pipeline with a duplicator, but nothing to read from its out socket.  Before the change, the duplicator will block forever in zmq.Socket.send() and stall the entire stack.  This change allows the stack to keep running, by dropping messages if the buffer is full and printing an error message to the logs