### PR TITLE
The mite browser is now dowloading all the embedded resources correctly

### DIFF
--- a/mite_browser/__init__.py
+++ b/mite_browser/__init__.py
@@ -108,9 +108,7 @@ class Resource:
     @property
     def _embeded_urls(self):
         """At the moment there is no reason to look for a url inside the resource source code such an image"""
-        for match in []:
-            """This will never be called"""
-            yield None, ""
+        return []
 
     @property
     def _resources_with_embedabbles(self):


### PR DESCRIPTION
The mite browser is now downloading all the embedded resources inside the stylesheet as it should do. Previously the research of embedded resources inside the stylesheet was disabled because it wasn't work properly. With the new changes it is enables and it works properly and it avoids to research embedded resource inside the resources founded (like for example searching a url inside an image).

About the new regex, the reason behind adding the `([^\"']*:)?` is because in general the embedded url in the css is like `url("path/to/resource/bla.bla")` but sometimes it is like `url("require:path/to/resource/bla.bla")`. For this reason, when needed, `match[2]` is used to get the whole and only url.