### PR TITLE
Refactoring in context.py

### DIFF
--- a/mite/context.py
+++ b/mite/context.py
@@ -59,13 +59,13 @@ class Context:
             if not is_handled:
                 e._mite_handled = True
                 if isinstance(e, MiteError):
-                    self._send_mite_error(e)
+                    await self._send_mite_error(e)
                 else:
-                    self._send_exception(e)
-            if self._debug:
-                breakpoint()
+                    await self._send_exception(e)
+                if self._debug:
+                    breakpoint()
             else:
-                raise
+                pass
         finally:
             await self._end_transaction()
 


### PR DESCRIPTION
- remove the should_stop_func argument from `__init__` (see #18), and the
  should_stop property
- rename self._send to self._send_fn.  Having both self.send and
  self._send was too confusing
- Refactor the context managers to use contextlib.asynccontextmanager.
  This makes the code much shorter and more intelligible