### PR TITLE
install git as a dependency in dockerfile

### DIFF
--- a/docker/PythonPackages/Dockerfile
+++ b/docker/PythonPackages/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.3-alpine3.9 
-RUN set -ex \ 
-    && apk add --no-cache gnupg libressl tar ca-certificates gcc cmake make libc-dev coreutils g++ libzmq zeromq zeromq-dev py3-zmq \
+FROM python:3.7.3-alpine3.9
+RUN set -ex \
+    && apk add --no-cache gnupg libressl tar ca-certificates gcc cmake make libc-dev coreutils g++ libzmq zeromq zeromq-dev py3-zmq git \
     && pip install -v cython msgpack-python ujson


### PR DESCRIPTION
The changes in #30 mean that we need a git executable present when we
are installing mite.  This change arranges for that to happen, and
restores the pipeline to green on jenkins.