### PR TITLE
Use the default eventloop if we are profiling

### DIFF
--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -474,7 +474,8 @@ def har_converter(opts):
 
 
 def main():
-    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    if os.environ.get("MITE_PROFILE", "0") != "1":
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
     opts = docopt.docopt(__doc__)
     setup_logging(opts)
     configure_python_path(opts)


### PR DESCRIPTION
uvloop doesnʼt let us get useful stacktraces in the profiler