### PR TITLE
Donʼt log the value of config variables that we set

### DIFF
--- a/mite/config.py
+++ b/mite/config.py
@@ -1,7 +1,6 @@
-from itertools import count
 import logging
 import os
-
+from itertools import count
 
 logger = logging.getLogger()
 
@@ -50,17 +49,10 @@ def default_config_loader():
     for name, value in os.environ.items():
         if name.startswith('MITE_CONF_'):
             key_name = name[10:]
-            logger.info(
-                'Setting config from ENV variable [%s] %s=%r', name, key_name, value
-            )
+            logger.info(f'Setting config "{key_name}" from environment variable')
             result[key_name] = value
         if name.startswith('MITE_EVAL_CONF_'):
             key_name = name[15:]
-            logger.info(
-                'Setting config from ENV variable and eval\'ing value [%s] %s=%r',
-                name,
-                key_name,
-                value,
-            )
+            logger.info(f'Setting config "{key_name}" by eval\'ing environment variable')
             result[key_name] = eval(value)
     return result


### PR DESCRIPTION
If the logs are captured somewhere, this leaks secrets.  If you want to
debug the setup of the config, then you can add debugging code to the
scenario function to do so (e.g. to dump the config to stdout, if thatʼs
what you want to do).