### PR TITLE
Add the ability to dump some messages for debugging to the duplicator

### DIFF
--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -71,6 +71,7 @@ import uvloop
 import msgpack
 
 from .cli.common import _create_config_manager
+from .cli.duplicator import duplicator
 from .cli.stats import stats
 from .collector import Collector
 from .controller import Controller
@@ -119,12 +120,6 @@ def _create_runner_transport(opts):
 def _create_controller_server(opts):
     socket = opts['--controller-socket']
     return _msg_backend_module(opts).ControllerServer(socket)
-
-
-def _create_duplicator(opts):
-    return _msg_backend_module(opts).Duplicator(
-        opts['--message-socket'], opts['OUT_SOCKET']
-    )
 
 
 logger = logging.getLogger(__name__)
@@ -398,11 +393,6 @@ def recorder(opts):
     recorder = Recorder(opts['--recorder-dir'])
     receiver.add_listener(recorder.process_message)
     asyncio.get_event_loop().run_until_complete(receiver.run())
-
-
-def duplicator(opts):
-    duplicator = _create_duplicator(opts)
-    asyncio.get_event_loop().run_until_complete(duplicator.run())
 
 
 def cat(opts):

--- a/mite/cli/duplicator.py
+++ b/mite/cli/duplicator.py
@@ -1,0 +1,20 @@
+import asyncio
+import signal
+
+from ..utils import _msg_backend_module
+
+
+def _create_duplicator(opts):
+    return _msg_backend_module(opts).Duplicator(
+        opts['--message-socket'], opts['OUT_SOCKET']
+    )
+
+
+def duplicator(opts):
+    duplicator = _create_duplicator(opts)
+
+    def handler(_signum, _stack_frame):
+        duplicator._debug_messages = 100
+
+    signal.signal(signal.SIGUSR1, handler)
+    asyncio.get_event_loop().run_until_complete(duplicator.run())

--- a/mite/cli/duplicator.py
+++ b/mite/cli/duplicator.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import signal
 
 from ..utils import _msg_backend_module
@@ -14,7 +15,20 @@ def duplicator(opts):
     duplicator = _create_duplicator(opts)
 
     def handler(_signum, _stack_frame):
-        duplicator._debug_messages = 100
+        messages_to_dump = 100
+        if "MITE_DEBUG_MESSAGES_TO_DUMP" in os.environ:
+            try:
+                messages_to_dump = int(os.environ["MITE_DEBUG_MESSAGES_TO_DUMP"])
+            except ValueError:
+                pass
+        else:
+            try:
+                with open(os.environ.get("MITE_DEBUG_MESSAGES_TO_DUMP_FILE",
+                                         "/tmp/mite_messages_to_dump")) as fin:
+                    messages_to_dump = int(fin.read().strip())
+            except (FileNotFoundError, ValueError):
+                pass
+        duplicator._debug_messages_to_dump = messages_to_dump
 
     signal.signal(signal.SIGUSR1, handler)
     asyncio.get_event_loop().run_until_complete(duplicator.run())

--- a/mite/zmq.py
+++ b/mite/zmq.py
@@ -22,7 +22,7 @@ class Duplicator:
         if loop is None:
             loop = asyncio.get_event_loop()
         self._loop = loop
-        self._debug_messages = 0
+        self._debug_messages_to_dump = 0
 
     async def run(self, stop_func=None):
         return await self._loop.run_in_executor(None, self._run, stop_func)
@@ -30,9 +30,9 @@ class Duplicator:
     def _run(self, stop_func=None):
         while stop_func is None or not stop_func():
             msg = self._in_socket.recv()
-            if self._debug_messages > 0:
+            if self._debug_messages_to_dump > 0:
                 sys.stdout.write(str(unpack_msg(msg)) + "\n")
-                self._debug_messages -= 1
+                self._debug_messages_to_dump -= 1
             for address, socket in self._out_sockets:
                 try:
                     socket.send(msg, flags=zmq.NOBLOCK)

--- a/test/perf/perftest.py
+++ b/test/perf/perftest.py
@@ -28,6 +28,8 @@ def run_test(scenario):
             )
         )
         duplicator = psutil.Popen(("mite", "duplicator", "tcp://127.0.0.1:14303"))
+        # TODO: we should make sure that the collector has a tmpfs in RAM to
+        # run in, so that disk performance doesn't get into the mix...
         collector = psutil.Popen(("mite", "collector"))
         controller = psutil.Popen(
             (

--- a/test/perf/run-perftest.sh
+++ b/test/perf/run-perftest.sh
@@ -2,6 +2,8 @@
 
 cd `git rev-parse --show-toplevel`
 
+mkdir -p test/perf/output
+
 # if ! git diff-index --quiet HEAD -- ; then
 #     echo "Repo is dirty!!!"
 #     exit 1


### PR DESCRIPTION
This allows us to do `kill -USR1 <pid>` and force the duplicator to dump
100 messages to stdout.  This is useful for debugging live systems,
especially in the cloud where inserting debugger breakpoints isnʼt
feasible.

Probably needs to be performance benchmarked.