### PR TITLE
Passing the opts from the config to the datapools

### DIFF
--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -210,11 +210,7 @@ def _create_runner(opts, transport, msg_sender):
 
 
 def _create_scenario_manager(opts):
-    return ScenarioManager(
-        start_delay=float(opts['--delay-start-seconds']),
-        period=float(opts['--max-loop-delay']),
-        spawn_rate=int(opts['--spawn-rate']),
-    )
+    return ScenarioManager(opts=opts)
 
 
 def test_scenarios(test_name, opts, scenarios, config_manager):

--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -210,7 +210,12 @@ def _create_runner(opts, transport, msg_sender):
 
 
 def _create_scenario_manager(opts):
-    return ScenarioManager(opts=opts)
+    return ScenarioManager(
+        start_delay=float(opts['--delay-start-seconds']),
+        period=float(opts['--max-loop-delay']),
+        spawn_rate=int(opts['--spawn-rate']),
+        config_manager=_create_config_manager(opts),
+    )
 
 
 def test_scenarios(test_name, opts, scenarios, config_manager):

--- a/mite/datapools.py
+++ b/mite/datapools.py
@@ -20,7 +20,7 @@ class RecyclableIterableDataPool:
             DataPoolItem(id, data) for id, data in enumerate(iterable, 1)
         )
 
-    async def checkout(self, **kwargs):
+    async def checkout(self, config):
         if self._available:
             dpi = self._available.popleft()
             self._checked_out[dpi.id] = dpi.data
@@ -52,7 +52,7 @@ class IterableFactoryDataPool:
             _id = next(counter)
             yield _id, data
 
-    async def checkout(self, **kwargs):
+    async def checkout(self, config):
         if not hasattr(self, '_cycle_gen_iter'):
             self._cycle_gen_iter = self._cycle()
         last_id = 0
@@ -74,7 +74,7 @@ class IterableDataPool:
         self._iter = iter(iterable)
         self._id_gen = count(1)
 
-    async def checkout(self, **kwargs):
+    async def checkout(self, config):
         try:
             data = next(self._iter)
         except StopIteration:

--- a/mite/datapools.py
+++ b/mite/datapools.py
@@ -20,7 +20,7 @@ class RecyclableIterableDataPool:
             DataPoolItem(id, data) for id, data in enumerate(iterable, 1)
         )
 
-    async def checkout(self):
+    async def checkout(self, **kwargs):
         if self._available:
             dpi = self._available.popleft()
             self._checked_out[dpi.id] = dpi.data
@@ -52,7 +52,7 @@ class IterableFactoryDataPool:
             _id = next(counter)
             yield _id, data
 
-    async def checkout(self):
+    async def checkout(self, **kwargs):
         if not hasattr(self, '_cycle_gen_iter'):
             self._cycle_gen_iter = self._cycle()
         last_id = 0
@@ -74,7 +74,7 @@ class IterableDataPool:
         self._iter = iter(iterable)
         self._id_gen = count(1)
 
-    async def checkout(self):
+    async def checkout(self, **kwargs):
         try:
             data = next(self._iter)
         except StopIteration:

--- a/mite/scenario.py
+++ b/mite/scenario.py
@@ -29,7 +29,7 @@ def _volume_dicts_remove_a_from_b(a, b):
 
 
 class ScenarioManager:
-    def __init__(self, opts=None):
+    def __init__(self, opts=dict()):
         self._opts = opts
         self._period = float(opts.get('--max-loop-delay', 1))
         self._scenario_id_gen = count(1)

--- a/mite/scenario.py
+++ b/mite/scenario.py
@@ -4,8 +4,6 @@ import time
 import logging
 import random
 
-from .cli.common import _create_config_manager
-
 from .datapools import DataPoolExhausted
 
 logger = logging.getLogger(__name__)
@@ -29,21 +27,17 @@ def _volume_dicts_remove_a_from_b(a, b):
 
 
 class ScenarioManager:
-    def __init__(self, opts=dict()):
-        self._opts = opts
-        self._period = float(opts.get('--max-loop-delay', 1))
+    def __init__(self, start_delay=0, period=1, spawn_rate=None, config_manager=None):
+        self._period = period
         self._scenario_id_gen = count(1)
-        self._start_delay = float(opts.get('--delay-start-seconds', 0))
-        self._in_start = self._start_delay > 0
+        self._in_start = start_delay > 0
+        self._start_delay = start_delay
         self._start_time = time.time()
         self._current_period_end = 0
-        spawn_rate = opts.get('--spawn-rate', None)
-        if spawn_rate:
-            self._spawn_rate = int(spawn_rate)
-        else:
-            self._spawn_rate = None
+        self._spawn_rate = spawn_rate
         self._required = {}
         self._scenarios = {}
+        self._config_manager = config_manager
 
     def _now(self):
         return time.time() - self._start_time
@@ -132,7 +126,7 @@ class ScenarioManager:
                 else:
                     try:
                         dpi = await scenario.datapool.checkout(
-                            opt=_create_config_manager(self._opts)
+                            config=self._config_manager
                         )
                     except DataPoolExhausted:
                         logger.info(

--- a/test/test_datapools.py
+++ b/test/test_datapools.py
@@ -1,5 +1,7 @@
 import pytest
 
+from mite.scenario import ScenarioManager
+
 from mite.datapools import (
     create_iterable_data_pool_with_recycling,
     create_iterable_data_pool,
@@ -10,23 +12,25 @@ import mite.datapools as dps
 
 @pytest.mark.asyncio
 async def test_recycling():
+    scenario_manager = ScenarioManager()
     iterable = 'abcdefgh'
     dp = create_iterable_data_pool_with_recycling(iterable)
     for i in range(len(iterable) * 20):
-        dpi = await dp.checkout()
+        dpi = await dp.checkout(scenario_manager)
         await dp.checkin(dpi.id)
-    assert (await dp.checkout()).data == 'a'
+    assert (await dp.checkout(scenario_manager)).data == 'a'
 
 
 @pytest.mark.asyncio
 async def test_iterable():
+    scenario_manager = ScenarioManager()
     iterable = 'abcdefgh'
     dp = create_iterable_data_pool(iterable)
     for i in range(len(iterable)):
-        dpi = await dp.checkout()
+        dpi = await dp.checkout(scenario_manager)
         await dp.checkin(dpi.id)
     try:
-        await dp.checkout()
+        await dp.checkout(scenario_manager)
     except DataPoolExhausted:
         pass
     else:
@@ -35,16 +39,17 @@ async def test_iterable():
 
 @pytest.mark.asyncio
 async def test_recyclable_is_exhausted():
+    scenario_manager = ScenarioManager()
     iterable = "ab"
     dp = dps.RecyclableIterableDataPool(iterable)
-    xa = await dp.checkout()
+    xa = await dp.checkout(scenario_manager)
     assert xa.data == "a"
-    x = await dp.checkout()
+    x = await dp.checkout(scenario_manager)
     assert x.data == "b"
-    x = await dp.checkout()
+    x = await dp.checkout(scenario_manager)
     assert x is None
     await dp.checkin(xa.id)
-    x = await dp.checkout()
+    x = await dp.checkout(scenario_manager)
     assert x.data == "a"
-    x = await dp.checkout()
+    x = await dp.checkout(scenario_manager)
     assert x is None


### PR DESCRIPTION
Because of a necessity I tried to add the opts from the config to the datapool.
As consequence I added to the datapools  a **kwargs argument in the checkout method that can be used for getting the necessary opts.