### PR TITLE
Make the message bus configurable for the journey/scenario test commands

### DIFF
--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -2,8 +2,8 @@
 Mite Load Test Framework.
 
 Usage:
-    mite [options] scenario test [--add-to-config=NEW_VALUE]... SCENARIO_SPEC
-    mite [options] journey test [--add-to-config=NEW_VALUE]... JOURNEY_SPEC [DATAPOOL_SPEC]
+    mite [options] scenario test [--add-to-config=NEW_VALUE]... [--message-processors=PROCESSORS] SCENARIO_SPEC
+    mite [options] journey test [--add-to-config=NEW_VALUE]... [--message-processors=PROCESSORS] JOURNEY_SPEC [DATAPOOL_SPEC]
     mite [options] controller SCENARIO_SPEC [--message-socket=SOCKET] [--controller-socket=SOCKET] [--logging-webhook=URL] [--add-to-config=NEW_VALUE]...
     mite [options] runner [--message-socket=SOCKET] [--controller-socket=SOCKET]
     mite [options] duplicator [--message-socket=SOCKET] OUT_SOCKET...
@@ -55,6 +55,7 @@ Options:
     --recorder-dir=DIRECTORY          Set the recorders output directory [default: recorder_data]
     --sleep-time=SLEEP                Set the second to await between each request [default: 1]
     --logging-webhook=URL             URL of an HTTP server to log test runs to
+    --message-processors=PROCESSORS   Classes to connect to the message bus for local testing [default: mite.logoutput:HttpStatsOutput,mite.logoutput:MsgOutput]
 """
 import asyncio
 import logging
@@ -65,22 +66,21 @@ from urllib.request import Request as UrlLibRequest
 from urllib.request import urlopen
 
 import docopt
+import msgpack
 import ujson
 
 import uvloop
-import msgpack
 
-from .cli.common import _create_config_manager
+from .cli.common import (_create_config_manager, _create_runner,
+                         _create_scenario_manager)
 from .cli.duplicator import duplicator
 from .cli.stats import stats
+from .cli.test import journey_cmd, scenario_cmd
 from .collector import Collector
 from .controller import Controller
 from .har_to_mite import har_convert_to_mite
-from .logoutput import HttpStatsOutput, MsgOutput
 from .recorder import Recorder
-from .runner import Runner
-from .scenario import ScenarioManager
-from .utils import _msg_backend_module, pack_msg, spec_import
+from .utils import _msg_backend_module, spec_import
 from .web import app, prometheus_metrics
 
 
@@ -125,52 +125,6 @@ def _create_controller_server(opts):
 logger = logging.getLogger(__name__)
 
 
-class DirectRunnerTransport:
-    def __init__(self, controller):
-        self._controller = controller
-
-    async def hello(self):
-        return self._controller.hello()
-
-    async def request_work(self, runner_id, current_work, completed_data_ids, max_work):
-        return await self._controller.request_work(
-            runner_id, current_work, completed_data_ids, max_work
-        )
-
-    async def bye(self, runner_id):
-        return self._controller.bye(runner_id)
-
-
-class DirectReciever:
-    def __init__(self):
-        self._listeners = []
-        self._raw_listeners = []
-
-    def add_listener(self, listener):
-        self._listeners.append(listener)
-
-    def add_raw_listener(self, raw_listener):
-        self._raw_listeners.append(raw_listener)
-
-    def recieve(self, msg):
-        for listener in self._listeners:
-            listener(msg)
-        packed_msg = pack_msg(msg)
-        for raw_listener in self._raw_listeners:
-            raw_listener(packed_msg)
-
-
-def _setup_msg_processors(receiver, opts):
-    collector = Collector(opts['--collector-dir'], int(opts['--collector-roll']))
-    recorder = Recorder(opts['--recorder-dir'])
-    msg_output = MsgOutput()
-    http_stats_output = HttpStatsOutput()
-    receiver.add_listener(http_stats_output.process_message)
-    receiver.add_listener(msg_output.process_message)
-    receiver.add_listener(recorder.process_message)
-    receiver.add_raw_listener(collector.process_raw_message)
-
-
 def _start_web_in_thread(opts):
     address = opts['--web-address']
     kwargs = {'port': 9301}
@@ -191,89 +145,6 @@ def _start_web_in_thread(opts):
     t = threading.Thread(target=app.run, name='mite.web', kwargs=kwargs)
     t.daemon = True
     t.start()
-
-
-def _create_runner(opts, transport, msg_sender):
-    loop_wait_max = float(opts['--max-loop-delay'])
-    loop_wait_min = float(opts['--min-loop-delay'])
-    max_work = None
-    if opts['--runner-max-journeys']:
-        max_work = int(opts['--runner-max-journeys'])
-    return Runner(
-        transport,
-        msg_sender,
-        loop_wait_min=loop_wait_min,
-        loop_wait_max=loop_wait_max,
-        max_work=max_work,
-        debug=opts['--debugging'],
-    )
-
-
-def _create_scenario_manager(opts):
-    return ScenarioManager(
-        start_delay=float(opts['--delay-start-seconds']),
-        period=float(opts['--max-loop-delay']),
-        spawn_rate=int(opts['--spawn-rate']),
-    )
-
-
-def test_scenarios(test_name, opts, scenarios, config_manager):
-    scenario_manager = _create_scenario_manager(opts)
-    for journey_spec, datapool, volumemodel in scenarios:
-        scenario_manager.add_scenario(journey_spec, datapool, volumemodel)
-    controller = Controller(test_name, scenario_manager, config_manager)
-    transport = DirectRunnerTransport(controller)
-    receiver = DirectReciever()
-    _setup_msg_processors(receiver, opts)
-    loop = asyncio.get_event_loop()
-
-    async def controller_report():
-        while True:
-            await asyncio.sleep(1)
-            controller.report(receiver.recieve)
-
-    loop.run_until_complete(
-        asyncio.gather(
-            controller_report(), _create_runner(opts, transport, receiver.recieve).run()
-        )
-    )
-
-
-def scenario_test_cmd(opts):
-    scenario_spec = opts['SCENARIO_SPEC']
-    scenarios_fn = spec_import(scenario_spec)
-    config_manager = _create_config_manager(opts)
-    try:
-        scenarios = scenarios_fn(config_manager)
-    except TypeError:
-        scenarios = scenarios_fn()
-    test_scenarios(scenario_spec, opts, scenarios, config_manager)
-
-
-def journey_test_cmd(opts):
-    journey_spec = opts['JOURNEY_SPEC']
-    datapool_spec = opts['DATAPOOL_SPEC']
-    if datapool_spec:
-        datapool = spec_import(datapool_spec)
-    else:
-        datapool = None
-    volumemodel = lambda start, end: int(opts['--volume'])
-    test_scenarios(
-        journey_spec,
-        opts,
-        [(journey_spec, datapool, volumemodel)],
-        _create_config_manager(opts),
-    )
-
-
-def scenario_cmd(opts):
-    if opts['test']:
-        scenario_test_cmd(opts)
-
-
-def journey_cmd(opts):
-    if opts['test']:
-        journey_test_cmd(opts)
 
 
 def _controller_log_start(scenario_spec, logging_url):

--- a/mite/cli/common.py
+++ b/mite/cli/common.py
@@ -1,4 +1,6 @@
 from ..config import ConfigManager
+from ..runner import Runner
+from ..scenario import ScenarioManager
 from ..utils import spec_import
 
 
@@ -11,3 +13,27 @@ def _create_config_manager(opts):
         k, v = value.split(":")
         config_manager.set(k, v)
     return config_manager
+
+
+def _create_scenario_manager(opts):
+    return ScenarioManager(
+        start_delay=float(opts['--delay-start-seconds']),
+        period=float(opts['--max-loop-delay']),
+        spawn_rate=int(opts['--spawn-rate']),
+    )
+
+
+def _create_runner(opts, transport, msg_sender):
+    loop_wait_max = float(opts['--max-loop-delay'])
+    loop_wait_min = float(opts['--min-loop-delay'])
+    max_work = None
+    if opts['--runner-max-journeys']:
+        max_work = int(opts['--runner-max-journeys'])
+    return Runner(
+        transport,
+        msg_sender,
+        loop_wait_min=loop_wait_min,
+        loop_wait_max=loop_wait_max,
+        max_work=max_work,
+        debug=opts['--debugging'],
+    )

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -1,0 +1,122 @@
+import asyncio
+import logging
+
+from ..collector import Collector
+from ..controller import Controller
+from ..recorder import Recorder
+from ..utils import pack_msg, spec_import
+from .common import (_create_config_manager, _create_runner,
+                     _create_scenario_manager)
+
+
+class DirectRunnerTransport:
+    def __init__(self, controller):
+        self._controller = controller
+
+    async def hello(self):
+        return self._controller.hello()
+
+    async def request_work(self, runner_id, current_work, completed_data_ids, max_work):
+        return self._controller.request_work(
+            runner_id, current_work, completed_data_ids, max_work
+        )
+
+    async def bye(self, runner_id):
+        return self._controller.bye(runner_id)
+
+
+class DirectReciever:
+    def __init__(self):
+        self._listeners = []
+        self._raw_listeners = []
+
+    def add_listener(self, listener):
+        self._listeners.append(listener)
+
+    def add_raw_listener(self, raw_listener):
+        self._raw_listeners.append(raw_listener)
+
+    def recieve(self, msg):
+        for listener in self._listeners:
+            listener(msg)
+        packed_msg = pack_msg(msg)
+        for raw_listener in self._raw_listeners:
+            raw_listener(packed_msg)
+
+
+def _setup_msg_processors(receiver, opts):
+    collector = Collector(opts['--collector-dir'], int(opts['--collector-roll']))
+    recorder = Recorder(opts['--recorder-dir'])
+    receiver.add_listener(recorder.process_message)
+    receiver.add_raw_listener(collector.process_raw_message)
+
+    extra_processors = [
+        spec_import(x)()
+        for x in opts["--message-processors"].split(",")
+    ]
+    for processor in extra_processors:
+        if hasattr(processor, "process_message"):
+            receiver.add_listener(processor.process_message)
+        elif hasattr(processor, "process_raw_message"):
+            receiver.add_raw_listener(processor.process_raw_message)
+        else:
+            logging.error(f"Class {processor.__name__} does not have a process(_raw)_message method!")
+
+
+def test_scenarios(test_name, opts, scenarios, config_manager):
+    scenario_manager = _create_scenario_manager(opts)
+    for journey_spec, datapool, volumemodel in scenarios:
+        scenario_manager.add_scenario(journey_spec, datapool, volumemodel)
+    controller = Controller(test_name, scenario_manager, config_manager)
+    transport = DirectRunnerTransport(controller)
+    receiver = DirectReciever()
+    _setup_msg_processors(receiver, opts)
+    loop = asyncio.get_event_loop()
+
+    async def controller_report():
+        while True:
+            await asyncio.sleep(1)
+            controller.report(receiver.recieve)
+
+    loop.run_until_complete(
+        asyncio.gather(
+            controller_report(), _create_runner(opts, transport, receiver.recieve).run()
+        )
+    )
+
+
+def scenario_test_cmd(opts):
+    scenario_spec = opts['SCENARIO_SPEC']
+    scenarios_fn = spec_import(scenario_spec)
+    config_manager = _create_config_manager(opts)
+    try:
+        scenarios = scenarios_fn(config_manager)
+    except TypeError:
+        scenarios = scenarios_fn()
+    test_scenarios(scenario_spec, opts, scenarios, config_manager)
+
+
+def journey_test_cmd(opts):
+    journey_spec = opts['JOURNEY_SPEC']
+    datapool_spec = opts['DATAPOOL_SPEC']
+    if datapool_spec:
+        datapool = spec_import(datapool_spec)
+    else:
+        datapool = None
+    volumemodel = lambda start, end: int(opts['--volume'])
+    test_scenarios(
+        journey_spec,
+        opts,
+        [(journey_spec, datapool, volumemodel)],
+        _create_config_manager(opts),
+    )
+
+
+def scenario_cmd(opts):
+    if opts['test']:
+        scenario_test_cmd(opts)
+
+
+def journey_cmd(opts):
+    if opts['test']:
+        journey_test_cmd(opts)


### PR DESCRIPTION
This allows us to do some fancy things.  Iʼve used this in chaos testing
to print out the request id of any request that takes longer than 5s.

(This change is technically not needed for the journey test command
itself, since we can print() from whereever we want in the code.  But it
allows us to test the message bus adapters that we write in the test
commands, eventually to plumb them into the message bus in a real
test – that is, this change facilitates debugging a custom component
like a stats, collector, etc. as part of journey test.)