### PR TITLE
Time function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/mite/__init__.py
+++ b/mite/__init__.py
@@ -9,6 +9,7 @@ import asyncio
 import random
 from pkg_resources import get_distribution, DistributionNotFound
 
+from .scenario import time_function  # noqa: F401
 from .exceptions import MiteError  # noqa: F401
 from .context import Context
 import mite.utils
@@ -29,7 +30,7 @@ def test_context(extensions=('http',), **config):
     return c
 
 
-class ensure_separation_from_callable:
+class _ensure_separation_from_callable:
     def __init__(self, sep_callable, loop=None):
         self._sep_callable = sep_callable
         self._loop = loop
@@ -65,7 +66,7 @@ def ensure_fixed_separation(separation, loop=None):
     def fixed_separation():
         return separation
 
-    return ensure_separation_from_callable(fixed_separation, loop=loop)
+    return _ensure_separation_from_callable(fixed_separation, loop=loop)
 
 
 def ensure_average_separation(mean_separation, plus_minus=None, loop=None):
@@ -88,4 +89,4 @@ def ensure_average_separation(mean_separation, plus_minus=None, loop=None):
     def average_separation():
         return mean_separation + (random.random() * plus_minus * 2) - plus_minus
 
-    return ensure_separation_from_callable(average_separation, loop=loop)
+    return _ensure_separation_from_callable(average_separation, loop=loop)

--- a/mite/cli/common.py
+++ b/mite/cli/common.py
@@ -1,7 +1,7 @@
 from ..config import ConfigManager
 from ..runner import Runner
 from ..scenario import ScenarioManager
-from ..utils import spec_import
+from ..utils import spec_import, _msg_backend_module
 
 
 def _create_config_manager(opts):
@@ -15,8 +15,9 @@ def _create_config_manager(opts):
     return config_manager
 
 
-def _create_scenario_manager(opts):
+def _create_scenario_manager(spec, opts):
     return ScenarioManager(
+        spec=spec,
         start_delay=float(opts['--delay-start-seconds']),
         period=float(opts['--max-loop-delay']),
         spawn_rate=int(opts['--spawn-rate']),
@@ -37,3 +38,10 @@ def _create_runner(opts, transport, msg_sender):
         max_work=max_work,
         debug=opts['--debugging'],
     )
+
+
+def _create_sender(opts):
+    socket = opts['--message-socket']
+    sender = _msg_backend_module(opts).Sender()
+    sender.connect(socket)
+    return sender

--- a/mite/cli/controller.py
+++ b/mite/cli/controller.py
@@ -1,14 +1,42 @@
-from .common import _create_config_manager, _create_scenario_manager, _create_sender
-from ..utils import spec_import, _msg_backend_module
-from ..controller import Controller
 import asyncio
-import os
 import logging
+from functools import partial
+
+from ..controller import Controller
+from ..utils import _msg_backend_module, spec_import
+from .common import (_create_config_manager, _create_scenario_manager,
+                     _create_sender)
 
 
 def _create_controller_server(opts):
     socket = opts['--controller-socket']
     return _msg_backend_module(opts).ControllerServer(socket)
+
+
+async def _run_time_function(time_fn, start_event, end_event):
+    if time_fn is not None:
+        await time_fn(start_event, end_event)
+        if not end_event.is_set():
+            logging.error(
+                "The time function exited before the scenario ended, which seems like a bug"
+            )
+    else:
+        start_event.set()
+        await end_event.wait()
+
+
+async def _send_controller_report(sender):
+    while True:
+        if controller.should_stop():
+            return
+        await asyncio.sleep(1)
+        controller.report(sender.send)
+
+
+async def _run_controller(server, controller, start_event, end_event):
+    await start_event.wait()
+    await server.run(controller, controller.should_stop)
+    end_event.set()
 
 
 def controller(opts):
@@ -26,60 +54,32 @@ def controller(opts):
     server = _create_controller_server(opts)
     sender = _create_sender(opts)
     loop = asyncio.get_event_loop()
-    # logging_id = None
-    # logging_url = opts["--logging-webhook"]
-    # if logging_url is None:
-    #     try:
-    #         logging_url = os.environ["MITE_LOGGING_URL"]
-    #     except KeyError:
-    #         pass
-    # if logging_url is not None:
-    #     logging_id = _controller_log_start(scenario_spec, logging_url)
-
     start_event = asyncio.Event()
     end_event = asyncio.Event()
 
-    async def run_time_function():
-        time_fn = getattr(scenarios_fn, "_mite_time_function", None)
-        if time_fn is not None:
-            await time_fn(scenario_spec, config_manager, start_event, end_event)
-            if not end_event.is_set():
-                logging.error(
-                    "The time function exited before the scenario ended, which seems like a bug"
-                )
-        else:
-            start_event.set()
-            await end_event.wait()
+    time_fn = getattr(scenarios_fn, "_mite_time_function", None)
+    if time_fn is not None:
+        time_fn = partial(time_fn, scenario_spec, config_manager)
 
-    async def controller_report():
-        while True:
-            if controller.should_stop():
-                return
-            await asyncio.sleep(1)
-            controller.report(sender.send)
-
-    async def run_controller():
-        await start_event.wait()
-        await server.run(controller, controller.should_stop)
-        end_event.set()
-
-    run_time_fn_task = asyncio.create_task(run_time_function())
+    time_fn_task = asyncio.create_task(_run_time_function(
+        time_fn, start_event, end_event
+    ))
 
     try:
         loop.run_until_complete(
             asyncio.gather(
-                controller_report(), run_controller(), run_time_fn_task
+                _send_controller_report(sender),
+                _run_controller(server, controller, start_event, end_event),
+                time_fn_task
             )
         )
     except KeyboardInterrupt:
         # TODO: kill runners, do other shutdown tasks
         logging.info("Received interrupt signal, shutting down")
         if not end_event.is_set():
-            run_time_fn_task.cancel()
-            loop.stop()
-            loop.run_until_complete(run_time_fn_task)
+            time_fn_task.cancel()
+            loop.run_until_complete(time_fn_task)
     finally:
-        _controller_log_end(logging_id, logging_url)
         # TODO: cancel all loop tasks?  Something must be done to stop this
         # from hanging
         loop.close()

--- a/mite/cli/controller.py
+++ b/mite/cli/controller.py
@@ -4,8 +4,7 @@ from functools import partial
 
 from ..controller import Controller
 from ..utils import _msg_backend_module, spec_import
-from .common import (_create_config_manager, _create_scenario_manager,
-                     _create_sender)
+from .common import _create_config_manager, _create_scenario_manager, _create_sender
 
 
 def _create_controller_server(opts):
@@ -39,7 +38,15 @@ async def _run_controller(server, controller_obj, start_event, end_event):
     end_event.set()
 
 
-def _run(scenario_spec, opts, scenarios_fn, server, sender, get_controller=Controller, extra_tasks=()):
+def _run(
+    scenario_spec,
+    opts,
+    scenarios_fn,
+    server,
+    sender,
+    get_controller=Controller,
+    extra_tasks=(),
+):
     config_manager = _create_config_manager(opts)
     scenario_manager = _create_scenario_manager(scenario_spec, opts)
     try:
@@ -58,9 +65,7 @@ def _run(scenario_spec, opts, scenarios_fn, server, sender, get_controller=Contr
     start_event = asyncio.Event()
     end_event = asyncio.Event()
 
-    time_fn_task = loop.create_task(_run_time_function(
-        time_fn, start_event, end_event
-    ))
+    time_fn_task = loop.create_task(_run_time_function(time_fn, start_event, end_event))
 
     try:
         loop.run_until_complete(

--- a/mite/cli/controller.py
+++ b/mite/cli/controller.py
@@ -1,0 +1,85 @@
+from .common import _create_config_manager, _create_scenario_manager, _create_sender
+from ..utils import spec_import, _msg_backend_module
+from ..controller import Controller
+import asyncio
+import os
+import logging
+
+
+def _create_controller_server(opts):
+    socket = opts['--controller-socket']
+    return _msg_backend_module(opts).ControllerServer(socket)
+
+
+def controller(opts):
+    config_manager = _create_config_manager(opts)
+    scenario_spec = opts['SCENARIO_SPEC']
+    scenarios_fn = spec_import(scenario_spec)
+    scenario_manager = _create_scenario_manager(scenario_spec, opts)
+    try:
+        scenarios = scenarios_fn(config_manager)
+    except TypeError:
+        scenarios = scenarios_fn()
+    for journey_spec, datapool, volumemodel in scenarios:
+        scenario_manager.add_scenario(journey_spec, datapool, volumemodel)
+    controller = Controller(scenario_manager, config_manager)
+    server = _create_controller_server(opts)
+    sender = _create_sender(opts)
+    loop = asyncio.get_event_loop()
+    # logging_id = None
+    # logging_url = opts["--logging-webhook"]
+    # if logging_url is None:
+    #     try:
+    #         logging_url = os.environ["MITE_LOGGING_URL"]
+    #     except KeyError:
+    #         pass
+    # if logging_url is not None:
+    #     logging_id = _controller_log_start(scenario_spec, logging_url)
+
+    start_event = asyncio.Event()
+    end_event = asyncio.Event()
+
+    async def run_time_function():
+        time_fn = getattr(scenarios_fn, "_mite_time_function", None)
+        if time_fn is not None:
+            await time_fn(scenario_spec, config_manager, start_event, end_event)
+            if not end_event.is_set():
+                logging.error(
+                    "The time function exited before the scenario ended, which seems like a bug"
+                )
+        else:
+            start_event.set()
+            await end_event.wait()
+
+    async def controller_report():
+        while True:
+            if controller.should_stop():
+                return
+            await asyncio.sleep(1)
+            controller.report(sender.send)
+
+    async def run_controller():
+        await start_event.wait()
+        await server.run(controller, controller.should_stop)
+        end_event.set()
+
+    run_time_fn_task = asyncio.create_task(run_time_function())
+
+    try:
+        loop.run_until_complete(
+            asyncio.gather(
+                controller_report(), run_controller(), run_time_fn_task
+            )
+        )
+    except KeyboardInterrupt:
+        # TODO: kill runners, do other shutdown tasks
+        logging.info("Received interrupt signal, shutting down")
+        if not end_event.is_set():
+            run_time_fn_task.cancel()
+            loop.stop()
+            loop.run_until_complete(run_time_fn_task)
+    finally:
+        _controller_log_end(logging_id, logging_url)
+        # TODO: cancel all loop tasks?  Something must be done to stop this
+        # from hanging
+        loop.close()

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -56,17 +56,16 @@ def _setup_msg_processors(receiver, opts):
     receiver.add_listener(recorder.process_message)
     receiver.add_raw_listener(collector.process_raw_message)
 
-    extra_processors = [
-        spec_import(x)()
-        for x in opts["--message-processors"].split(",")
-    ]
+    extra_processors = [spec_import(x)() for x in opts["--message-processors"].split(",")]
     for processor in extra_processors:
         if hasattr(processor, "process_message"):
             receiver.add_listener(processor.process_message)
         elif hasattr(processor, "process_raw_message"):
             receiver.add_raw_listener(processor.process_raw_message)
         else:
-            logging.error(f"Class {processor.__name__} does not have a process(_raw)_message method!")
+            logging.error(
+                f"Class {processor.__name__} does not have a process(_raw)_message method!"
+            )
 
 
 def test_scenarios(scenario_spec, opts, scenario_fn):
@@ -87,7 +86,7 @@ def test_scenarios(scenario_spec, opts, scenario_fn):
         server,
         sender,
         get_controller=get_controller,
-        extra_tasks=(_create_runner(opts, transport, sender.receive).run(),)
+        extra_tasks=(_create_runner(opts, transport, sender.receive).run(),),
     )
 
 
@@ -110,9 +109,7 @@ def journey_test_cmd(opts):
         return [(journey_spec, datapool, volumemodel)]
 
     test_scenarios(
-        journey_spec,
-        opts,
-        dummy_scenario,
+        journey_spec, opts, dummy_scenario,
     )
 
 

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -1,10 +1,11 @@
+import asyncio
 import logging
 
 from ..collector import Collector
 from ..controller import Controller
 from ..recorder import Recorder
 from ..utils import pack_msg, spec_import
-from .common import _create_config_manager, _create_runner
+from .common import _create_runner
 from .controller import _run as _run_controller
 
 
@@ -40,6 +41,12 @@ class DirectReciever:
             raw_listener(packed_msg)
 
 
+class DummyServer:
+    async def run(controller, stop_func):
+        while stop_func is None or not stop_func():
+            await asyncio.sleep(5)
+
+
 def _setup_msg_processors(receiver, opts):
     collector = Collector(opts['--collector-dir'], int(opts['--collector-roll']))
     recorder = Recorder(opts['--recorder-dir'])
@@ -60,7 +67,7 @@ def _setup_msg_processors(receiver, opts):
 
 
 def test_scenarios(scenario_spec, opts, scenario_fn):
-    server = FIXME
+    server = DummyServer()
     sender = DirectReciever()
     transport = DirectRunnerTransport()
 

--- a/mite/controller.py
+++ b/mite/controller.py
@@ -71,8 +71,7 @@ class RunnerTracker:
 
 
 class Controller:
-    def __init__(self, testname, scenario_manager, config_manager):
-        self._testname = testname
+    def __init__(self, scenario_manager, config_manager):
         self._scenario_manager = scenario_manager
         self._runner_id_gen = count(1)
         self._work_tracker = WorkTracker()
@@ -83,7 +82,7 @@ class Controller:
         runner_id = next(self._runner_id_gen)
         return (
             runner_id,
-            self._testname,
+            self._scenario_manager.spec,
             self._config_manager.get_changes_for_runner(runner_id),
         )
 
@@ -125,7 +124,7 @@ class Controller:
             {
                 'type': 'controller_report',
                 'time': time.time(),
-                'test': self._testname,
+                'test': self._scenario_manager.spec,
                 'required': required,
                 'actual': dict(actual),
                 'num_runners': len(active_runner_ids),

--- a/mite/lib/logging_webhook.py
+++ b/mite/lib/logging_webhook.py
@@ -51,5 +51,11 @@ def _controller_log_end(logging_id, logging_url):
     logging.debug("Logging test end complete")
 
 
-def time_function(scenario_spec, config_manager, start_event, end_event):
-    _controller_log_start()
+def log(scenario_spec, config_manager, start_event, end_event):
+    url = config_manager.get("logging_webhook_url")
+    logging_id = _controller_log_start(scenario_spec, url)
+    start_event.set()
+    try:
+        await end_event.wait()
+    finally:
+        _controller_log_end(logging_id, url)

--- a/mite/lib/logging_webhook.py
+++ b/mite/lib/logging_webhook.py
@@ -1,0 +1,55 @@
+import logging
+from urllib.request import Request as UrlLibRequest
+from urllib.request import urlopen
+
+import ujson
+
+
+def _controller_log_start(scenario_spec, logging_url):
+    if not logging_url.endswith("/"):
+        logging_url += "/"
+
+    url = logging_url + "start"
+    logging.info(f"Logging test start to {url}")
+    resp = urlopen(
+        UrlLibRequest(
+            url,
+            data=ujson.dumps(
+                {
+                    'testname': scenario_spec,
+                    # TODO: log other properties as well,
+                    # like the endpoint URLs we are
+                    # hitting.
+                }
+            ).encode(),
+            method="POST",
+        )
+    )
+    logging.debug("Logging test start complete")
+    if resp.status == 200:
+        return ujson.loads(resp.read())['newid']
+    else:
+        logging.warning(
+            f"Could not complete test start logging; status was {resp.status_code}"
+        )
+
+
+def _controller_log_end(logging_id, logging_url):
+    if logging_id is None:
+        return
+
+    if not logging_url.endswith("/"):
+        logging_url += "/"
+
+    url = logging_url + "end"
+    logging.info(f"Logging test end to {url}")
+    resp = urlopen(UrlLibRequest(url, data=ujson.dumps({'id': logging_id}).encode()))
+    if resp.status != 204:
+        logging.warning(
+            f"Could not complete test end logging; status was {resp.status_code}"
+        )
+    logging.debug("Logging test end complete")
+
+
+def time_function(scenario_spec, config_manager, start_event, end_event):
+    _controller_log_start()

--- a/mite/lib/logging_webhook.py
+++ b/mite/lib/logging_webhook.py
@@ -51,7 +51,7 @@ def _controller_log_end(logging_id, logging_url):
     logging.debug("Logging test end complete")
 
 
-def log(scenario_spec, config_manager, start_event, end_event):
+async def log(scenario_spec, config_manager, start_event, end_event):
     url = config_manager.get("logging_webhook_url")
     logging_id = _controller_log_start(scenario_spec, url)
     start_event.set()

--- a/mite/scenario.py
+++ b/mite/scenario.py
@@ -178,4 +178,5 @@ def time_function(tf_name):
     def decorator_inner(fn):
         fn._mite_time_function = tf_name
         return fn
+
     return decorator_inner

--- a/mite/scenario.py
+++ b/mite/scenario.py
@@ -27,7 +27,8 @@ def _volume_dicts_remove_a_from_b(a, b):
 
 
 class ScenarioManager:
-    def __init__(self, start_delay=0, period=1, spawn_rate=None):
+    def __init__(self, spec, start_delay=0, period=1, spawn_rate=None):
+        self._spec = spec
         self._period = period
         self._scenario_id_gen = count(1)
         self._in_start = start_delay > 0
@@ -37,6 +38,10 @@ class ScenarioManager:
         self._spawn_rate = spawn_rate
         self._required = {}
         self._scenarios = {}
+
+    @property
+    def spec(self):
+        return self._spec
 
     def _now(self):
         return time.time() - self._start_time
@@ -167,3 +172,10 @@ class ScenarioManager:
         for scenario_id, scenario_data_id in ids:
             if scenario_id in self._scenarios:
                 await self._scenarios[scenario_id].datapool.checkin(scenario_data_id)
+
+
+def time_function(tf_name):
+    def decorator_inner(fn):
+        fn._mite_time_function = tf_name
+        return fn
+    return decorator_inner

--- a/test/test_cli_common.py
+++ b/test/test_cli_common.py
@@ -1,0 +1,22 @@
+from mite.cli.common import _create_config_manager
+
+
+def dummy_config():
+    return {"foo": "bar"}
+
+
+def test_create_config_manager():
+    cm = _create_config_manager({
+        "--config": "test_cli_common:dummy_config",
+        "--add-to-config": (),
+    })
+    assert cm.get("foo") == "bar"
+
+
+def test_create_config_manager_add_to_config():
+    cm = _create_config_manager({
+        "--config": "test_cli_common:dummy_config",
+        "--add-to-config": ("abc:xyz",),
+    })
+    assert cm.get("foo") == "bar"
+    assert cm.get("abc") == "xyz"

--- a/test/test_cli_common.py
+++ b/test/test_cli_common.py
@@ -6,17 +6,15 @@ def dummy_config():
 
 
 def test_create_config_manager():
-    cm = _create_config_manager({
-        "--config": "test_cli_common:dummy_config",
-        "--add-to-config": (),
-    })
+    cm = _create_config_manager(
+        {"--config": "test_cli_common:dummy_config", "--add-to-config": ()}
+    )
     assert cm.get("foo") == "bar"
 
 
 def test_create_config_manager_add_to_config():
-    cm = _create_config_manager({
-        "--config": "test_cli_common:dummy_config",
-        "--add-to-config": ("abc:xyz",),
-    })
+    cm = _create_config_manager(
+        {"--config": "test_cli_common:dummy_config", "--add-to-config": ("abc:xyz",)}
+    )
     assert cm.get("foo") == "bar"
     assert cm.get("abc") == "xyz"

--- a/test/test_cli_controller.py
+++ b/test/test_cli_controller.py
@@ -1,0 +1,57 @@
+import asyncio
+from unittest import mock
+from unittest.mock import call
+
+import pytest
+from mite.cli.controller import _run_time_function
+
+
+@pytest.mark.asyncio
+class TestRunTimeFunction:
+    async def test_none(self):
+        s = asyncio.Event()
+        e = asyncio.Event()
+
+        async def co():
+            await asyncio.sleep(0.01)
+            e.set()
+
+        await asyncio.gather(co(), _run_time_function(None, s, e))
+        assert s.is_set()
+
+    async def test_time_fn(self):
+        s = asyncio.Event()
+        e = asyncio.Event()
+
+        async def co():
+            await asyncio.sleep(0.01)
+            e.set()
+
+        async def tf(s, e):
+            assert not s.is_set()
+            s.set()
+            await e.wait()
+
+        await asyncio.gather(co(), _run_time_function(tf, s, e))
+        assert s.is_set()
+        assert e.is_set()
+
+    async def test_early_return(self):
+        s = asyncio.Event()
+        e = asyncio.Event()
+
+        async def co():
+            await asyncio.sleep(0.01)
+            e.set()
+
+        async def tf(s, e):
+            assert not s.is_set()
+            s.set()
+
+        with mock.patch("logging.error") as m:
+            await asyncio.gather(co(), _run_time_function(tf, s, e))
+            assert s.is_set()
+            assert e.is_set()
+            assert m.call_args_list == [
+                call('The time function exited before the scenario ended, which seems like a bug'),
+            ]

--- a/test/test_cli_controller.py
+++ b/test/test_cli_controller.py
@@ -53,5 +53,7 @@ class TestRunTimeFunction:
             assert s.is_set()
             assert e.is_set()
             assert m.call_args_list == [
-                call('The time function exited before the scenario ended, which seems like a bug'),
+                call(
+                    'The time function exited before the scenario ended, which seems like a bug'
+                ),
             ]

--- a/test/test_controller.py
+++ b/test/test_controller.py
@@ -3,21 +3,18 @@ from mite.scenario import ScenarioManager
 from mite.config import ConfigManager
 from werkzeug.wrappers import Response
 import ujson
-from mite.__main__ import _controller_log_start, _controller_log_end
+from mite.lib.logging_webhook import _controller_log_start, _controller_log_end
 from pytest_httpserver.httpserver import HandlerType
 import json
 
 
-TESTNAME = "unit_test_name"
-
-
 def test_controller_hello():
-    scenario_manager = ScenarioManager()
+    scenario_manager = ScenarioManager("test_123")
     config_manager = ConfigManager()
-    controller = Controller(TESTNAME, scenario_manager, config_manager)
+    controller = Controller(scenario_manager, config_manager)
     for i in range(5):
         runner_id, test_name, config_list = controller.hello()
-        assert test_name == controller._testname
+        assert test_name == "test_123"
         assert runner_id == i + 1
 
 

--- a/test/test_scenario.py
+++ b/test/test_scenario.py
@@ -57,7 +57,7 @@ test_num_runners = 1
 
 
 def test_add_scenario():
-    scenario_manager = ScenarioManager()
+    scenario_manager = ScenarioManager("test")
     for row in test_scenarios:
         scenario_manager.add_scenario(row[0], row[1], row[2])
     for i in scenario_manager._scenarios:
@@ -65,7 +65,7 @@ def test_add_scenario():
 
 
 def test_upadate_required_work():
-    scenario_manager = ScenarioManager()
+    scenario_manager = ScenarioManager("test")
     for row in test_scenarios:
         scenario_manager.add_scenario(row[0], row[1], row[2])
     scenario_manager._update_required_and_period(5, 10)
@@ -76,7 +76,7 @@ def test_upadate_required_work():
 @pytest.mark.asyncio
 async def test_get_work():
 
-    scenario_manager = ScenarioManager()
+    scenario_manager = ScenarioManager("test")
     for row in test_scenarios:
         scenario_manager.add_scenario(row[0], row[1], row[2])
     scenario_manager._update_required_and_period(5, 10)


### PR DESCRIPTION
Add a concept of "time function" to mite.  This is a function that is run in the controller alongside the main controller logic.  It receives two `asyncio.Event` objects: one which it can use to gate the start of the test, and one it can use to listen for the end of the test.  We are able to port the previously added "logging webhook" feature to be a generic time function.  We have other use cases in our private testing code as well.  One is at https://github.com/sky-uk/id-mite-nft/blob/8e8f8e10672d0903aceb253d81dd600fe8a65390/mite_id/ims/journeys.py#L200 (where we purge rabbit queues at the start of a test; currently we just use the beginning of the scenario function for this) and for our upcoming chaos testing deliverables (where we want to run not only at the beginning of the test, but during it as well).

Main changes:
- implementation logic for the above
- add a decorator `time_function` to the mite top-level module.  When applied to a scenario function, it marks the scenario to be used with the time function.
- port the logging webhook to be a time function instead (now in `lib/logging_webhook.py`)
- add some unit tests for this functionality (principally, the logic of `asyncio.Event` sequencing)

Consequent changes:
- `mite/__init__.py`: add underscore prefixes to private names
- move the controller logic from `__main__.py` to a new file `cli/controller.py`
- refactor `ScenarioManager` to know the spec of the scenario it represents.  `Controller` objects no longer need to know this; they can read it from their ScenarioManager.
- refactor the `mite controller` and `mite (journey|scenario) test` CLI commands to use the same code path.  This allows changes like this one introducing time functions to be made in only one place, rather than two.

Outstanding tasks:
- [ ] documentation
- [ ] consider whether, for the sake of modularity/composability, we should allow multiple time functions to be specified.
- [ ] consider whether to allow specifying a time function on the command line and/or via environment variables, in addition to as a decorator
- [ ] consider whether there's a better name than "time function" for this feature