### PR TITLE
Several changes

### DIFF
--- a/acurl/tests/test_httpbin.py
+++ b/acurl/tests/test_httpbin.py
@@ -1,5 +1,6 @@
-import acurl
 from urllib.parse import urlencode
+
+import acurl
 import pytest
 
 
@@ -9,6 +10,7 @@ def session():
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 async def test_get():
     s = session()
     r = await s.get('https://httpbin.org/ip')
@@ -19,6 +21,7 @@ async def test_get():
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 async def test_cookies():
     s = session()
     r = await s.get('https://httpbin.org/cookies/set?name=value')
@@ -26,6 +29,7 @@ async def test_cookies():
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 async def test_session_cookies():
     s = session()
     await s.get('https://httpbin.org/cookies/set?name=value')
@@ -38,6 +42,7 @@ async def test_session_cookies():
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 async def test_set_cookies():
     s = session()
     await s.get('https://httpbin.org/cookies/set?name=value')
@@ -48,6 +53,7 @@ async def test_set_cookies():
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 async def test_basic_auth():
     s = session()
     r = await s.get(
@@ -57,6 +63,7 @@ async def test_basic_auth():
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 async def test_failed_basic_auth():
     s = session()
     r = await s.get(
@@ -66,6 +73,7 @@ async def test_failed_basic_auth():
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 async def test_redirect():
     s = session()
     url = 'https://httpbin.org/ip'

--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -58,6 +58,7 @@ Options:
     --message-processors=PROCESSORS   Classes to connect to the message bus for local testing [default: mite.logoutput:HttpStatsOutput,mite.logoutput:MsgOutput]
 """
 import asyncio
+import inspect
 import logging
 import os
 import sys
@@ -71,8 +72,7 @@ import ujson
 
 import uvloop
 
-from .cli.common import (_create_config_manager, _create_runner,
-                         _create_scenario_manager)
+from .cli.common import _create_config_manager, _create_runner, _create_scenario_manager
 from .cli.duplicator import duplicator
 from .cli.stats import stats
 from .cli.test import journey_cmd, scenario_cmd
@@ -201,15 +201,25 @@ def controller(opts):
     scenario_spec = opts['SCENARIO_SPEC']
     scenarios_fn = spec_import(scenario_spec)
     scenario_manager = _create_scenario_manager(opts)
-    try:
-        scenarios = scenarios_fn(config_manager)
-    except TypeError:
-        scenarios = scenarios_fn()
+    sender = _create_sender(opts)
+    # Inject arguments into the scenario
+    scenarios_kwargs = {}
+    scenarios_signature = inspect.signature(scenarios_fn)
+    for param in scenarios_signature.parameters:
+        if param.name == "config":
+            scenarios_kwargs["config"] = config_manager
+        elif param.name == "sender":
+            scenarios_kwargs["sender"] = sender
+        else:
+            raise Exception(
+                f"Don't know how to inject {param.name} into a scenario function!"
+            )
+    scenarios = scenarios_fn(**scenarios_kwargs)
     for journey_spec, datapool, volumemodel in scenarios:
         scenario_manager.add_scenario(journey_spec, datapool, volumemodel)
+    # Done setting up scenarios
     controller = Controller(scenario_spec, scenario_manager, config_manager)
     server = _create_controller_server(opts)
-    sender = _create_sender(opts)
     loop = asyncio.get_event_loop()
     logging_id = None
     logging_url = opts["--logging-webhook"]

--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -205,14 +205,14 @@ def controller(opts):
     # Inject arguments into the scenario
     scenarios_kwargs = {}
     scenarios_signature = inspect.signature(scenarios_fn)
-    for param in scenarios_signature.parameters:
-        if param.name == "config":
+    for param_name in scenarios_signature.parameters:
+        if param_name == "config":
             scenarios_kwargs["config"] = config_manager
-        elif param.name == "sender":
+        elif param_name == "sender":
             scenarios_kwargs["sender"] = sender
         else:
             raise Exception(
-                f"Don't know how to inject {param.name} into a scenario function!"
+                f"Don't know how to inject {param_name} into a scenario function!"
             )
     scenarios = scenarios_fn(**scenarios_kwargs)
     for journey_spec, datapool, volumemodel in scenarios:

--- a/mite/stats.py
+++ b/mite/stats.py
@@ -68,7 +68,7 @@ class Gauge(Stat):
     def process(self, msg):
         if self.matcher(msg):
             for key, value in self.extractor.extract(msg):
-                self.metrics[key] += value
+                self.metrics[key] = value
 
     def dump(self):
         metrics = dict(self.metrics)

--- a/mite/zmq.py
+++ b/mite/zmq.py
@@ -187,3 +187,4 @@ class ControllerServer:
                 self._sock.send(pack_msg(controller.bye(content)))
             else:
                 raise Exception(f"something weird happened! _type is {_type}")
+            await asyncio.sleep(0)

--- a/mite/zmq.py
+++ b/mite/zmq.py
@@ -187,4 +187,7 @@ class ControllerServer:
                 self._sock.send(pack_msg(controller.bye(content)))
             else:
                 raise Exception(f"something weird happened! _type is {_type}")
+            # Insert a zero-length sleep to allow asyncio to service other
+            # coroutines.  Notably, this allows the controller report sending
+            # coroutine to run.
             await asyncio.sleep(0)

--- a/test/test_recorder.py
+++ b/test/test_recorder.py
@@ -21,7 +21,7 @@ def test_process_message_right_content():
         recorder = Recorder(target_dir=tempdir)
         recorder.process_message(msg_create)
         with open(os.path.join(tempdir, msg_create['name'] + '.msgpack'), "rb") as f:
-            unpacked = msgpack.Unpacker(f, encoding='utf-8', use_list=False)
+            unpacked = msgpack.Unpacker(f, raw=False, use_list=False)
             assert next(unpacked) == data_value
 
 

--- a/test/test_runner_tracker.py
+++ b/test/test_runner_tracker.py
@@ -1,12 +1,18 @@
-from mite.controller import RunnerTracker
 import time
+
+import pytest
+from mite.controller import RunnerTracker
 
 
 def test_remove_runner():
     runner_tracker = RunnerTracker()
-    runner_tracker._last_seen = {1: 1539012109.6872835, 2: 1539012109.6883354,
-                                 3: 1539012109.6891248, 4: 1539012109.6899157,
-                                 5: 1539012109.6907856}
+    runner_tracker._last_seen = {
+        1: 1539012109.6872835,
+        2: 1539012109.6883354,
+        3: 1539012109.6891248,
+        4: 1539012109.6899157,
+        5: 1539012109.6907856,
+    }
     for i in range(1, 6):
         runner_tracker.remove_runner(i)
         assert i not in runner_tracker._last_seen
@@ -20,6 +26,7 @@ def test_update():
         assert len(runner_tracker._hits) == i - 9
 
 
+@pytest.mark.slow
 def test_update_popleft():
     runner_tracker = RunnerTracker(2)
     for i in range(3):
@@ -30,6 +37,7 @@ def test_update_popleft():
     assert len(runner_tracker._hits) == 5
 
 
+@pytest.mark.slow
 def test_get_hit_rate():
     runner_tracker = RunnerTracker(2)
     for i in range(3):
@@ -40,6 +48,7 @@ def test_get_hit_rate():
     assert runner_tracker.get_hit_rate() == 1
 
 
+@pytest.mark.slow
 def test_get_active():
     runner_tracker = RunnerTracker(2)
     for i in range(5):

--- a/test/test_stats.py
+++ b/test/test_stats.py
@@ -94,11 +94,11 @@ class TestGauge:
         gauge.process(None)
         assert dict(gauge.metrics) == {"foo": 3.0}
 
-    def test_process_additivity(self):
+    def test_process_non_additivity(self):
         gauge = Gauge("test", lambda x: True, self.dummy_extractor)
         gauge.process(None)
         gauge.process(None)
-        assert dict(gauge.metrics) == {"foo": 6.0}
+        assert dict(gauge.metrics) == {"foo": 3.0}
 
     def test_dump(self):
         gauge = Gauge("test", lambda x: True, self.dummy_extractor)

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ commands =
 
 [pytest]
 addopts = --cov
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
Substantive changes:
- Change the semantics of the `Gauge` stat to report the last-seen value, not a sum.  We have the "Counter" and "Accumulator" stats for reporting sums.
  - Consequent change to the tests
- Fix a bug whereby the controller was not sending its reports, and therefore the `mite_runner_count` metric (and a couple others) would not appear in prometheus
  - Add a test for this
- Allow the scenario function to receive a sender object for the mite data pipeline if needed.  Dependency-inject this, and the config argument, "properly" (by looking at the signature of the function).

Test changes:
- introduce a "slow" mark for tests.  You can skip the slow tests locally by running `pytest -m "not slow"`
- fix a deprecation warning in the test suite from msgpack library

At https://github.com/sky-uk/mite/pull/120/files#diff-f768c2d8aec809f495425dbf2bdb92f3R88 we have an example of running the "real" runner, duplicator, and controller with the multiprocessing module.  This might be interesting beyond the test suite, so I call attention to it here.

The above changes are to support the chaos testing with tc in our private test suite code.