### PR TITLE
First commit for a mite websocket adaptor

### DIFF
--- a/mite_websocket/__init__.py
+++ b/mite_websocket/__init__.py
@@ -1,0 +1,53 @@
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+
+import websockets
+from websockets.exceptions import WebSocketException
+
+from mite.exceptions import MiteError
+
+
+logger = logging.getLogger(__name__) 
+
+
+class WebsocketError(MiteError): 
+    pass
+
+
+class _WebsocketWrapper:
+    def __init__(self):
+        self.connection = None
+
+    def install(self, context):
+        context.websocket = self
+
+    def uninstall(self, context):
+        del context.websocket
+
+    async def connect(self, *args, **kwargs):
+        self.connection = await websockets.connect(*args, **kwargs)
+        return self.connection 
+
+    async def send(self, body, **kwargs):
+        await self.connection.send(body)
+
+
+@asynccontextmanager
+async def _websocket_context_manager(context):
+    ww = _WebsocketWrapper()
+    ww.install(context)
+    try:
+        yield
+    except WebSocketException as e:
+        raise WebsocketError(e) from e
+    finally:
+        ww.uninstall(context)
+
+
+def mite_websocket(func):
+    async def wrapper(ctx, *args, **kwargs):
+        async with _websocket_context_manager(ctx):
+            return await func(ctx, *args, **kwargs)
+
+    return wrapper

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ install_requires =
     pyzmq
     selenium
     uvloop
+    websockets
 setup_requires = pytest-runner
 tests_require = pytest
 packages = find:

--- a/test/test_mite_websockets.py
+++ b/test/test_mite_websockets.py
@@ -1,0 +1,67 @@
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from asyncmock import AsyncMock
+from mocks.mock_context import MockContext
+
+import websockets
+from websockets.exceptions import WebSocketException
+from mite_websocket import _WebsocketWrapper, mite_websocket, WebsocketError
+
+
+@pytest.mark.asyncio
+async def test_mite_websocket_decorator():
+    context = MockContext()
+
+    @mite_websocket
+    async def dummy_journey(ctx):
+        assert ctx.websocket is not None
+
+    await dummy_journey(context)
+
+
+@pytest.mark.asyncio
+async def test_mite_websocket_decorator_uninstall():
+    context = MockContext()
+
+    @mite_websocket
+    async def dummy_journey(ctx):
+        pass
+
+    await dummy_journey(context)
+
+    assert getattr(context, "websocket", None) is None
+
+
+@pytest.mark.asyncio
+async def test_mite_websocket_connect_and_send():
+    context = MockContext()
+    url = "wss://foo.bar"
+    message = "baz"
+    connect_mock = AsyncMock()
+
+    @mite_websocket
+    async def dummy_journey(ctx):
+        await ctx.websocket.connect(url)
+        await ctx.websocket.send(message)
+
+    with patch("websockets.connect", new=connect_mock):
+        await dummy_journey(context)
+
+    connect_mock.assert_called_once_with(url)
+    connect_mock.return_value.send.assert_called_once_with(message)
+
+
+@pytest.mark.asyncio
+async def test_mite_websocket_exception_handling():
+    context = MockContext()
+
+    @mite_websocket
+    async def dummy_journey(ctx):
+        raise WebSocketException("Something went wrong")
+
+    with pytest.raises(WebsocketError):
+        await dummy_journey(context)
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ source =
     mite_browser
     mite_selenium
     mite_amqp
+    mite_websocket
 
 [coverage:report]
 # Regexes for lines to exclude from consideration


### PR DESCRIPTION
* Pretty lightweight and similar to the amqp one
* Adds websocket attribute to conext using wrapper
* Uses connect method to establish websocket connection, which both returns the connection object and sets a websocket.connection attribute to the established connection
* websocket.send(...) will then send over this connection
* if more connections are needed, you can assign returned connection from connect(...). Unsure if this is best design
* 100% unit test coverage
* Cool new exception chaining feature I've never used before