### PR TITLE
Mite websocket update

### DIFF
--- a/mite_websocket/__init__.py
+++ b/mite_websocket/__init__.py
@@ -15,25 +15,29 @@ class WebsocketError(MiteError):
 
 class _WebsocketWrapper:
     def __init__(self):
-        self.connection = None
+        self.connections = []
 
     def install(self, context):
         context.websocket = self
 
     async def uninstall(self, context):
-        if self.connection:
-            await self.connection.close()
+        for conn in self.connections:
+            if conn:
+                await self.close_connection(conn)
         del context.websocket
 
     async def connect(self, *args, **kwargs):
-        self.connection = await websockets.connect(*args, **kwargs)
-        return self.connection
+        conn = await websockets.connect(*args, **kwargs)
+        self.connections.append(conn)
+        return conn
 
-    async def send(self, body, **kwargs):
-        await self.connection.send(body)
+    def get_connections(self):
+        return self.connections
 
-    async def recv(self):
-        return await self.connection.recv()
+    async def close_connection(self, conn):
+        await conn.close()
+        self.connections.remove(conn)
+        del conn
 
 
 @asynccontextmanager

--- a/mite_websocket/__init__.py
+++ b/mite_websocket/__init__.py
@@ -32,6 +32,9 @@ class _WebsocketWrapper:
     async def send(self, body, **kwargs):
         await self.connection.send(body)
 
+    async def recv(self):
+        return await self.connection.recv()
+
 
 @asynccontextmanager
 async def _websocket_context_manager(context):

--- a/mite_websocket/__init__.py
+++ b/mite_websocket/__init__.py
@@ -37,7 +37,6 @@ class _WebsocketWrapper:
     async def close_connection(self, conn):
         await conn.close()
         self.connections.remove(conn)
-        del conn
 
 
 @asynccontextmanager

--- a/test/test_mite_websockets.py
+++ b/test/test_mite_websockets.py
@@ -52,6 +52,24 @@ async def test_mite_websocket_connect_and_send():
     connect_mock.assert_called_once_with(url)
     connect_mock.return_value.send.assert_called_once_with(message)
 
+@pytest.mark.asyncio
+async def test_mite_websocket_connect_and_recv():
+   context = MockContext()
+   url = "wss://foo.bar"
+   connect_mock = AsyncMock()
+
+   @mite_websocket
+   async def dummy_journey(ctx):
+       await ctx.websocket.connect(url)
+       await ctx.websocket.recv()
+
+   with patch ("websockets.connect", new=connect_mock):
+       await dummy_journey(context)
+
+   connect_mock.assert_called_once_with(url)
+   connect_mock.return_value.recv.assert_called_once()
+
+
 
 @pytest.mark.asyncio
 async def test_mite_websocket_exception_handling():

--- a/test/test_mite_websockets.py
+++ b/test/test_mite_websockets.py
@@ -29,7 +29,7 @@ async def test_mite_websocket_decorator_uninstall():
         await ctx.websocket.connect("wss://foo.bar")
 
     with patch("websockets.connect", new=connect_mock):
-        wb = await dummy_journey(context)
+        await dummy_journey(context)
 
     assert getattr(context, "websocket", None) is None
 

--- a/test/test_mite_websockets.py
+++ b/test/test_mite_websockets.py
@@ -51,6 +51,39 @@ async def test_mite_websocket_connect():
 
 
 @pytest.mark.asyncio
+async def test_mite_websocket_connect_and_send():
+    context = MockContext()
+    url = "wss://foo.bar"
+    msg = "bar"
+    connect_mock = AsyncMock()
+
+    @mite_websocket
+    async def dummy_journey(ctx):
+        return await ctx.websocket.connect(url)
+
+    with patch("websockets.connect", new=connect_mock):
+        wb = await dummy_journey(context)
+    await wb.send(msg)
+    connect_mock.return_value.send.assert_called_once_with(msg)
+
+
+@pytest.mark.asyncio
+async def test_mite_websocket_connect_and_recv():
+    context = MockContext()
+    url = "wss://foo.bar"
+    connect_mock = AsyncMock()
+
+    @mite_websocket
+    async def dummy_journey(ctx):
+        return await ctx.websocket.connect(url)
+
+    with patch("websockets.connect", new=connect_mock):
+        wb = await dummy_journey(context)
+    await wb.recv()
+    connect_mock.return_value.recv.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_mite_websocket_exception_handling():
     context = MockContext()
 

--- a/test/test_mite_websockets.py
+++ b/test/test_mite_websockets.py
@@ -29,46 +29,25 @@ async def test_mite_websocket_decorator_uninstall():
         await ctx.websocket.connect("wss://foo.bar")
 
     with patch("websockets.connect", new=connect_mock):
-        await dummy_journey(context)
+        wb = await dummy_journey(context)
 
     assert getattr(context, "websocket", None) is None
 
 
 @pytest.mark.asyncio
-async def test_mite_websocket_connect_and_send():
+async def test_mite_websocket_connect():
     context = MockContext()
     url = "wss://foo.bar"
-    message = "baz"
     connect_mock = AsyncMock()
 
     @mite_websocket
     async def dummy_journey(ctx):
         await ctx.websocket.connect(url)
-        await ctx.websocket.send(message)
 
     with patch("websockets.connect", new=connect_mock):
         await dummy_journey(context)
 
     connect_mock.assert_called_once_with(url)
-    connect_mock.return_value.send.assert_called_once_with(message)
-
-@pytest.mark.asyncio
-async def test_mite_websocket_connect_and_recv():
-   context = MockContext()
-   url = "wss://foo.bar"
-   connect_mock = AsyncMock()
-
-   @mite_websocket
-   async def dummy_journey(ctx):
-       await ctx.websocket.connect(url)
-       await ctx.websocket.recv()
-
-   with patch ("websockets.connect", new=connect_mock):
-       await dummy_journey(context)
-
-   connect_mock.assert_called_once_with(url)
-   connect_mock.return_value.recv.assert_called_once()
-
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
After founding out that in the current state I wasn't able to receive the message from the server I did some changes.

- When a connection is created it will be added on a list and returned. 
- To send and receive messages is enough to use the returned obj from the connection method.
- There is a new method to get the list of created connection
- A new close method as been added. It will close the connection, remove it from the list and delete it. 
- At the end the whole list will be scanned and all the connection closed.