### PR TITLE
Update test suite for python3.8

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,4 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 known_first_party=_acurl
-known_third_party = aio_pika,altair,asyncmock,bs4,docopt,flask,ipdb,jinja2,mocks,msgpack,nanomsg,pandas,pkg_resources,psutil,pytest,pytest_httpserver,sanic,selenium,setuptools,ujson,uvloop,websockets,werkzeug,zmq
+known_third_party = aio_pika,altair,bs4,docopt,flask,ipdb,jinja2,mocks,msgpack,nanomsg,pandas,pkg_resources,psutil,pytest,pytest_httpserver,sanic,selenium,setuptools,ujson,uvloop,websockets,werkzeug,zmq

--- a/test/test_mite_amqp.py
+++ b/test/test_mite_amqp.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 
 import aio_pika
 import pytest
-from asyncmock import AsyncMock
 from mocks.mock_context import MockContext
 
 from mite_amqp import _AMQPWrapper, mite_amqp
@@ -34,15 +33,12 @@ async def test_mite_amqp_decorator_uninstall():
 
 
 @pytest.mark.asyncio
-# FIXME new for 3.8
-# @unittest.mock.patch("aio_pika.connect")
+@patch("aio_pika.connect")
 # FIXME this test fails under tox, passes(?) otherwise
 @pytest.mark.xfail(strict=False)
-async def test_mite_amqp_connect():
+async def test_mite_amqp_connect(connect_mock):
     context = MockContext()
     url = "amqp://foo.bar"
-
-    connect_mock = AsyncMock()
 
     @mite_amqp
     async def dummy_journey(ctx):
@@ -55,13 +51,12 @@ async def test_mite_amqp_connect():
 
 
 @pytest.mark.asyncio
+@patch("aio_pika.connect")
 # FIXME this test fails under tox, passes(?) otherwise
 @pytest.mark.xfail(strict=False)
-async def test_mite_amqp_connect_robust():
+async def test_mite_amqp_connect_robust(connect_mock):
     context = MockContext()
     url = "amqp://foo.bar"
-
-    connect_mock = AsyncMock()
 
     @mite_amqp
     async def dummy_journey(ctx):

--- a/test/test_mite_websockets.py
+++ b/test/test_mite_websockets.py
@@ -1,7 +1,6 @@
 from unittest.mock import patch
 
 import pytest
-from asyncmock import AsyncMock
 from mocks.mock_context import MockContext
 from websockets.exceptions import WebSocketException
 
@@ -20,65 +19,61 @@ async def test_mite_websocket_decorator():
 
 
 @pytest.mark.asyncio
-async def test_mite_websocket_decorator_uninstall():
+@patch("websockets.connect")
+async def test_mite_websocket_decorator_uninstall(connect_mock):
     context = MockContext()
-    connect_mock = AsyncMock()
 
     @mite_websocket
     async def dummy_journey(ctx):
         await ctx.websocket.connect("wss://foo.bar")
 
-    with patch("websockets.connect", new=connect_mock):
-        await dummy_journey(context)
+    await dummy_journey(context)
 
     assert getattr(context, "websocket", None) is None
 
 
 @pytest.mark.asyncio
-async def test_mite_websocket_connect():
+@patch("websockets.connect")
+async def test_mite_websocket_connect(connect_mock):
     context = MockContext()
     url = "wss://foo.bar"
-    connect_mock = AsyncMock()
 
     @mite_websocket
     async def dummy_journey(ctx):
         await ctx.websocket.connect(url)
 
-    with patch("websockets.connect", new=connect_mock):
-        await dummy_journey(context)
+    await dummy_journey(context)
 
     connect_mock.assert_called_once_with(url)
 
 
 @pytest.mark.asyncio
-async def test_mite_websocket_connect_and_send():
+@patch("websockets.connect")
+async def test_mite_websocket_connect_and_send(connect_mock):
     context = MockContext()
     url = "wss://foo.bar"
     msg = "bar"
-    connect_mock = AsyncMock()
 
     @mite_websocket
     async def dummy_journey(ctx):
         return await ctx.websocket.connect(url)
 
-    with patch("websockets.connect", new=connect_mock):
-        wb = await dummy_journey(context)
+    wb = await dummy_journey(context)
     await wb.send(msg)
     connect_mock.return_value.send.assert_called_once_with(msg)
 
 
 @pytest.mark.asyncio
-async def test_mite_websocket_connect_and_recv():
+@patch("websockets.connect")
+async def test_mite_websocket_connect_and_recv(connect_mock):
     context = MockContext()
     url = "wss://foo.bar"
-    connect_mock = AsyncMock()
 
     @mite_websocket
     async def dummy_journey(ctx):
         return await ctx.websocket.connect(url)
 
-    with patch("websockets.connect", new=connect_mock):
-        wb = await dummy_journey(context)
+    wb = await dummy_journey(context)
     await wb.recv()
     connect_mock.return_value.recv.assert_called_once()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,5 @@
 [tox]
-# can't enable py38 yet because of many packages that aren't yet updated
-# for it, including (at time of writing) numpy:
-# https://github.com/numpy/numpy/issues/13927
-envlist = py37
+envlist = py38
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
The major change is that we can use the builtin mock library, since it
learned how to cope with async things in 3.8