### PR TITLE
Split stats into their own modules

### DIFF
--- a/mite_http/__init__.py
+++ b/mite_http/__init__.py
@@ -1,62 +1,11 @@
 import asyncio
 import logging
-import os
 from collections import deque
 from contextlib import asynccontextmanager
 
 from acurl import EventLoop
-from mite.stats import Counter, Histogram, extractor, matcher_by_type
 
 logger = logging.getLogger(__name__)
-
-
-def _generate_stats():
-    bins = [
-        float(x)
-        for x in os.environ.get(
-            "MITE_HTTP_HISTOGRAM_BUCKETS",
-            "0.0001,0.001,0.01,0.05,0.1,0.2,0.4,0.8,1,2,4,8,16,32,64",
-        ).split(",")
-    ]
-
-    return (
-        Counter(
-            name='mite_http_response_total',
-            matcher=matcher_by_type('http_metrics'),
-            extractor=extractor('test journey transaction method response_code'.split()),
-        ),
-        Histogram(
-            name='mite_http_response_time_seconds',
-            matcher=matcher_by_type('http_metrics'),
-            extractor=extractor(['transaction'], 'total_time'),
-            bins=bins,
-        ),
-    )
-
-
-_MITE_STATS = _generate_stats()
-
-
-def _generate_dns_stats():
-    bins = [
-        float(x)
-        for x in os.environ.get(
-            "MITE_DNS_HISTOGRAM_BUCKETS",
-            "0.0001,0.001,0.01,0.05,0.1,0.2,0.4,0.8,1,2,4,8,16,32,64",
-        ).split(",")
-    ]
-
-    return (
-        Histogram(
-            name='mite_dns_time',
-            matcher=matcher_by_type('http_metrics'),
-            extractor=extractor(['transaction'], 'dns_time'),
-            bins=bins,
-        ),
-    )
-
-
-_MITE_DNS_STATS = _generate_dns_stats()
 
 
 @asynccontextmanager

--- a/mite_http/stats.py
+++ b/mite_http/stats.py
@@ -1,0 +1,52 @@
+import os
+
+from mite.stats import Counter, Histogram, extractor, matcher_by_type
+
+
+def _generate_stats():
+    bins = [
+        float(x)
+        for x in os.environ.get(
+            "MITE_HTTP_HISTOGRAM_BUCKETS",
+            "0.0001,0.001,0.01,0.05,0.1,0.2,0.4,0.8,1,2,4,8,16,32,64",
+        ).split(",")
+    ]
+
+    return (
+        Counter(
+            name='mite_http_response_total',
+            matcher=matcher_by_type('http_metrics'),
+            extractor=extractor('test journey transaction method response_code'.split()),
+        ),
+        Histogram(
+            name='mite_http_response_time_seconds',
+            matcher=matcher_by_type('http_metrics'),
+            extractor=extractor(['transaction'], 'total_time'),
+            bins=bins,
+        ),
+    )
+
+
+STATS = _generate_stats()
+
+
+def _generate_dns_stats():
+    bins = [
+        float(x)
+        for x in os.environ.get(
+            "MITE_DNS_HISTOGRAM_BUCKETS",
+            "0.0001,0.001,0.01,0.05,0.1,0.2,0.4,0.8,1,2,4,8,16,32,64",
+        ).split(",")
+    ]
+
+    return (
+        Histogram(
+            name='mite_dns_time',
+            matcher=matcher_by_type('http_metrics'),
+            extractor=extractor(['transaction'], 'dns_time'),
+            bins=bins,
+        ),
+    )
+
+
+DNS_STATS = _generate_dns_stats()

--- a/mite_selenium/__init__.py
+++ b/mite_selenium/__init__.py
@@ -1,26 +1,11 @@
 import logging
 from contextlib import asynccontextmanager
 
-from mite.stats import Counter, Histogram, extractor, matcher_by_type
-from mite.utils import spec_import
 from selenium.webdriver import Remote
 
+from mite.utils import spec_import
+
 logger = logging.getLogger(__name__)
-
-
-_MITE_STATS = (
-    Histogram(
-        'mite_http_selenium_response_time_seconds',
-        matcher_by_type('http_selenium_metrics'),
-        extractor=extractor(['transaction'], 'total_time'),
-        bins=[0.0001, 0.001, 0.01, 0.05, 0.1, 0.2, 0.4, 0.8, 1, 2, 4, 8, 16, 32, 64],
-    ),
-    Counter(
-        'mite_http_selenium_response_total',
-        matcher_by_type('http_selenium_metrics'),
-        extractor('test journey transaction'.split()),
-    ),
-)
 
 
 class _SeleniumWrapper:

--- a/mite_selenium/stats.py
+++ b/mite_selenium/stats.py
@@ -1,0 +1,15 @@
+from mite.stats import Counter, Histogram, extractor, matcher_by_type
+
+STATS = (
+    Histogram(
+        'mite_http_selenium_response_time_seconds',
+        matcher_by_type('http_selenium_metrics'),
+        extractor=extractor(['transaction'], 'total_time'),
+        bins=[0.0001, 0.001, 0.01, 0.05, 0.1, 0.2, 0.4, 0.8, 1, 2, 4, 8, 16, 32, 64],
+    ),
+    Counter(
+        'mite_http_selenium_response_total',
+        matcher_by_type('http_selenium_metrics'),
+        extractor('test journey transaction'.split()),
+    ),
+)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,8 @@ console_scripts =
     mite = mite.__main__:main
 mite_stats =
     mite = mite.stats:_MITE_STATS
-    mite_http = mite_http:_MITE_STATS
-    mite_selenium = mite_selenium:_MITE_STATS
+    mite_http = mite_http.stats:STATS
+    mite_selenium = mite_selenium.stats:STATS
 
 [options.packages.find]
 exclude =

--- a/test/test_mite_http.py
+++ b/test/test_mite_http.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from mocks.mock_context import MockContext
 
-import mite_http as mite_http_module
+import mite_http.stats
 from mite_http import SessionPool, mite_http
 
 
@@ -42,7 +42,7 @@ def test_default_histogram_bins():
     if "MITE_HTTP_HISTOGRAM_BUCKETS" in os.environ:
         del os.environ["MITE_HTTP_HISTOGRAM_BUCKETS"]
 
-    stats = mite_http_module._generate_stats()
+    stats = mite_http.stats._generate_stats()
     assert stats[1].bins == [
         0.0001,
         0.001,
@@ -64,7 +64,7 @@ def test_default_histogram_bins():
 
 def test_non_default_bins():
     os.environ["MITE_HTTP_HISTOGRAM_BUCKETS"] = "1,2,3"
-    stats = mite_http_module._generate_stats()
+    stats = mite_http.stats._generate_stats()
     assert stats[1].bins == [1, 2, 3]
 
 

--- a/test/test_mite_http.py
+++ b/test/test_mite_http.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 from mocks.mock_context import MockContext
 
-import mite_http.stats
+import mite_http.stats as mite_http_stats
 from mite_http import SessionPool, mite_http
 
 
@@ -42,7 +42,7 @@ def test_default_histogram_bins():
     if "MITE_HTTP_HISTOGRAM_BUCKETS" in os.environ:
         del os.environ["MITE_HTTP_HISTOGRAM_BUCKETS"]
 
-    stats = mite_http.stats._generate_stats()
+    stats = mite_http_stats._generate_stats()
     assert stats[1].bins == [
         0.0001,
         0.001,
@@ -64,7 +64,7 @@ def test_default_histogram_bins():
 
 def test_non_default_bins():
     os.environ["MITE_HTTP_HISTOGRAM_BUCKETS"] = "1,2,3"
-    stats = mite_http.stats._generate_stats()
+    stats = mite_http_stats._generate_stats()
     assert stats[1].bins == [1, 2, 3]
 
 


### PR DESCRIPTION
Weʼve seen memory usage slowly balloon in the stats component when new
modules pull in new dependencies.  The best pattern for keeping mem
usage low seems to be to keep the stats definitions in separate modules,
which this PR implements for mite core.