### PR TITLE
Fix bug introduced with msgpack upgrade

### DIFF
--- a/mite/utils.py
+++ b/mite/utils.py
@@ -5,7 +5,7 @@ import msgpack
 
 
 def unpack_msg(msg):  # pragma: no cover
-    return msgpack.unpackb(msg, use_list=False, raw=False)
+    return msgpack.unpackb(msg, use_list=False, raw=False, strict_map_key=False)
 
 
 def pack_msg(msg):  # pragma: no cover


### PR DESCRIPTION
strict_map_key prevents using integers as map keys when we unpack
messages (only str and bytes are allowed).  But the runner wire format
uses ints as keys.  The point of the setting of this option to true by
default is to be secure against hashtable-based DoS attacks.  But since
this is a mite-internal protocol, I think we are safe to set it to false.