### PR TITLE
Accurate tracebacks

### DIFF
--- a/mite/context.py
+++ b/mite/context.py
@@ -1,19 +1,43 @@
+import contextlib
 import logging
 import sys
 import time
 import traceback
-from itertools import count
-
 from contextlib import asynccontextmanager
-from .exceptions import MiteError
+from itertools import count
+from pathlib import PurePath
 
+from .exceptions import MiteError
 
 logger = logging.getLogger(__name__)
 
+_HERE = PurePath(__file__).parent
+_MITE_HTTP = _HERE.parent / "mite_http"
+# FIXME: if the mite_http module was installed at mite.http, then we could
+# omit this hack, and just use the (single) directory of the mite library for
+# the checks.  But that would require a change in the way we package mite,
+# which we might or might not ultimately want.  See also:
+# https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
+# Further FIXME: add the other built-in mite modules to the list of paths to
+# exclude
+_MITE_LIB_PATHS = {str(p) for p in (_HERE, _MITE_HTTP)}
+
 
 def _tb_format_location(tb):
-    f_code = tb.tb_frame.f_code
-    return f"{f_code.co_filename}:{tb.tb_lineno}:{f_code.co_name}"
+    try:
+        frame = tb.tb_frame
+        while (
+            any(frame.f_code.co_filename.startswith(p) for p in _MITE_LIB_PATHS)
+            or frame.f_code.co_filename == contextlib.__file__
+        ):
+            # Keep walking the stack frames until we get to something that's
+            # not in mite code, nor in the stdlib's contextlib module (which
+            # also shows up in our backtraces).
+            frame = frame.f_back
+        f_code = frame.f_code
+        return f"{f_code.co_filename}:{f_code.co_firstlineno}:{f_code.co_name}"
+    except Exception:
+        return "unable_to_format_source:0:none"
 
 
 class Context:
@@ -84,6 +108,9 @@ class Context:
         ex_type = type(value).__name__
         tb = sys.exc_info()[2]
         location = _tb_format_location(tb)
+        # FIXME: this winds up sending quite a lot of data on the wire that we
+        # don't actually use most of the time... do we want to make it
+        # configurable whether to send this?
         stacktrace = ''.join(traceback.format_tb(tb))
         self.send(
             'exception',

--- a/test/test_context.py
+++ b/test/test_context.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import Mock
 
 import pytest
@@ -126,3 +127,17 @@ async def test_mite_error():
 
     end_msg = send_fn.call_args_list[1][0][0]
     assert end_msg["type"] == "txn"
+
+
+@pytest.mark.asyncio
+async def test_mite_error_backtrace_points_to_exn_source():
+    send_fn = Mock()
+    context = Context(send_fn, {})
+
+    with raises(Exception):
+        async with context.transaction("test"):
+            raise Exception("foo")
+
+    assert send_fn.call_args_list[0][0][0]["location"].startswith(
+        os.path.abspath(__file__)
+    )


### PR DESCRIPTION
Implement stack-walking logic for error reporting in mite.  This (finally) stops all the errors in the mite dashboard from being reported at the same location `/home/aecay/work/id-mite-nft/mite/mite/context.py:59:transaction`