### PR TITLE
Adding a session wrapper for additional metrics

### DIFF
--- a/mite_browser/__init__.py
+++ b/mite_browser/__init__.py
@@ -88,7 +88,7 @@ class Browser:
         """Perform a request and return a page object"""
         # Wrap everything in page object
         embedded_res = kwargs.pop("embedded_res", self._embedded_res)
-        resp = await self._session.getattr("request")(method, url, *args, **kwargs)
+        resp = await self._session.request(method, url, *args, **kwargs)
         page = Page(resp, self)
         if embedded_res:
             async with self._ctx.transaction(

--- a/mite_browser/__init__.py
+++ b/mite_browser/__init__.py
@@ -88,7 +88,7 @@ class Browser:
         """Perform a request and return a page object"""
         # Wrap everything in page object
         embedded_res = kwargs.pop("embedded_res", self._embedded_res)
-        resp = await self._session.request(method, url, *args, **kwargs)
+        resp = await self._session.getattr("request")(method, url, *args, **kwargs)
         page = Page(resp, self)
         if embedded_res:
             async with self._ctx.transaction(

--- a/mite_http/__init__.py
+++ b/mite_http/__init__.py
@@ -16,7 +16,7 @@ class AcurlSessionWrapper:
 
     def getattr(self, attrname):
         try:
-            r = object.___getattr__(self, attrname)
+            r = object.__getattr__(self, attrname)
             return r
         except AttributeError:
             pass

--- a/mite_http/__init__.py
+++ b/mite_http/__init__.py
@@ -14,7 +14,8 @@ class AcurlSessionWrapper:
         self.__callback = None
         self.additional_metrics = {}
 
-    def getattr(self, attrname):
+    def __getattr__(self, attrname):
+
         try:
             r = object.__getattr__(self, attrname)
             return r

--- a/mite_http/__init__.py
+++ b/mite_http/__init__.py
@@ -31,7 +31,6 @@ class AcurlSessionWrapper:
         return self.__callback
 
 
-
 class SessionPool:
     """No longer actually goes pooling as this is built into acurl. API just left in place.
     Will need a refactor"""
@@ -71,7 +70,6 @@ class SessionPool:
         def response_callback(r):
             if session_wrapper._response_callback is not None:
                 session_wrapper._response_callback(r, session_wrapper.additional_metrics)
-
 
             context.send(
                 'http_metrics',

--- a/mite_http/__init__.py
+++ b/mite_http/__init__.py
@@ -8,12 +8,27 @@ from acurl import EventLoop
 logger = logging.getLogger(__name__)
 
 
-@asynccontextmanager
-async def _session_pool_context_manager(session_pool, context):
-    context.http = await session_pool._checkout(context)
-    yield
-    await session_pool._checkin(context.http)
-    del context.http
+class AcurlSessionWrapper:
+    def __init__(self, session):
+        self.__session = session
+        self.__callback = None
+        self.additional_metrics = {}
+
+    def getattr(self, attrname):
+        try:
+            r = object.___getattr__(self, attrname)
+            return r
+        except AttributeError:
+            pass
+        return getattr(self.__session, attrname)
+
+    def set_response_callback(self, cb):
+        self.__callback = cb
+
+    @property
+    def _response_callback(self):
+        return self.__callback
+
 
 
 class SessionPool:
@@ -27,8 +42,12 @@ class SessionPool:
         self._el = EventLoop()
         self._pool = deque()
 
-    def session_context(self, context):
-        return _session_pool_context_manager(self, context)
+    @asynccontextmanager
+    async def session_context(self, context):
+        context.http = await self._checkout(context)
+        yield
+        await self._checkin(context.http)
+        del context.http
 
     @classmethod
     def decorator(cls, func):
@@ -46,11 +65,12 @@ class SessionPool:
 
     async def _checkout(self, context):
         session = self._el.session()
-        session.additional_metrics = {}
+        session_wrapper = AcurlSessionWrapper(session)
 
         def response_callback(r):
-            additional_metrics = session.additional_metrics
-            session.additional_metrics = {}
+            if session_wrapper._response_callback is not None:
+                session_wrapper._response_callback(r, session_wrapper.additional_metrics)
+
 
             context.send(
                 'http_metrics',
@@ -65,11 +85,11 @@ class SessionPool:
                 total_time=r.total_time,
                 primary_ip=r.primary_ip,
                 method=r.request.method,
-                **additional_metrics,
+                **session_wrapper.additional_metrics,
             )
 
         session.set_response_callback(response_callback)
-        return session
+        return session_wrapper
 
     async def _checkin(self, session):
         pass


### PR DESCRIPTION
Adding a Session wrapper in mite_http in order to allow the session modification without break the original mite session.