### PR TITLE
Fix a bug where on recent versions of curl cookies wouldnʼt work properly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: stable
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3.8
   - repo: https://gitlab.com/pycqa/flake8
     rev: master
     hooks:

--- a/acurl/src/response.c
+++ b/acurl/src/response.c
@@ -62,6 +62,9 @@ void start_request(struct aeEventLoop *UNUSED(eventLoop), int UNUSED(fd), void *
     if(rd->auth != NULL) {
         curl_easy_setopt(rd->curl, CURLOPT_USERPWD, rd->auth);
     }
+    // An empty string enables the cookie engine without adding any
+    // cookies: https://curl.haxx.se/libcurl/c/CURLOPT_COOKIEFILE.html
+    curl_easy_setopt(rd->curl, CURLOPT_COOKIEFILE, "");
     for(int i=0; i < rd->cookies_len; i++) {
         DEBUG_PRINT("set cookie [%s]", rd->cookies_str[i]);
         curl_easy_setopt(rd->curl, CURLOPT_COOKIELIST, rd->cookies_str[i]);

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     -rrequirements.txt
 commands =
     pytest {posargs}
+sitepackages = true
 
 [pytest]
 addopts = --cov
@@ -16,7 +17,7 @@ markers =
 
 [coverage:run]
 branch = True
-omit = 
+omit =
     acurl/tests/*
     mite/example.py
 source =


### PR DESCRIPTION
I believe this was introduced by https://github.com/curl/curl/pull/4434