### PR TITLE
Fixes for mite traceback reporting

### DIFF
--- a/mite/context.py
+++ b/mite/context.py
@@ -1,4 +1,3 @@
-import contextlib
 import logging
 import sys
 import time
@@ -25,26 +24,17 @@ _MITE_LIB_PATHS = {str(p) for p in (_HERE, _MITE_HTTP)}
 
 def _tb_format_location(tb):
     try:
-        frame = tb.tb_frame
-        while (
-            any(frame.f_code.co_filename.startswith(p) for p in _MITE_LIB_PATHS)
-            or frame.f_code.co_filename == contextlib.__file__
-        ):
-            # Keep walking the stack frames until we get to something that's
-            # not in mite code, nor in the stdlib's contextlib module (which
-            # also shows up in our backtraces).
-            frame = frame.f_back
-        f_code = frame.f_code
-        return f"{f_code.co_filename}:{f_code.co_firstlineno}:{f_code.co_name}"
+        stack_summary = traceback.extract_tb(tb, limit=-1)[0]
+        return f"{stack_summary.filename}:{stack_summary.lineno}:{stack_summary.name}"
     except Exception:
         return "unable_to_format_source:0:none"
 
 
 class Context:
-    def __init__(self, send_fn, config, id_data={}, should_stop_func=None, debug=False):
+    def __init__(self, send_fn, config, id_data=None, should_stop_func=None, debug=False):
         self._send_fn = send_fn
         self._config = config
-        self._id_data = id_data
+        self._id_data = id_data or {}
         self._should_stop_func = should_stop_func
         self._transaction_id = None
         self._transaction_name = None
@@ -100,17 +90,14 @@ class Context:
                 raise
         finally:
             self.send(
-                'txn',
-                start_time=start_time,
-                end_time=time.time(),
-                had_error=error,
+                'txn', start_time=start_time, end_time=time.time(), had_error=error,
             )
             self._transaction_name = old_transaction_name
             self._transaction_id = old_transaction_id
 
-    def _send_exception(self, value):
-        message = str(value)
-        ex_type = type(value).__name__
+    def _send_exception(self, exn):
+        message = traceback.format_exception_only(type(exn), exn)[-1].strip()
+        ex_type = type(exn).__name__
         tb = sys.exc_info()[2]
         location = _tb_format_location(tb)
         # FIXME: this winds up sending quite a lot of data on the wire that we
@@ -125,7 +112,8 @@ class Context:
             stacktrace=stacktrace,
         )
 
-    def _send_mite_error(self, value):
+    def _send_mite_error(self, exn):
         tb = sys.exc_info()[2]
         location = _tb_format_location(tb)
-        self.send('error', message=str(value), location=location, **value.fields)
+        message = traceback.format_exception_only(type(exn), exn)[-1].strip()
+        self.send('error', message=message, location=location, **exn.fields)

--- a/mite/context.py
+++ b/mite/context.py
@@ -90,7 +90,10 @@ class Context:
                 raise
         finally:
             self.send(
-                'txn', start_time=start_time, end_time=time.time(), had_error=error,
+                'txn',
+                start_time=start_time,
+                end_time=time.time(),
+                had_error=error,
             )
             self._transaction_name = old_transaction_name
             self._transaction_id = old_transaction_id
@@ -113,5 +116,9 @@ class Context:
             stacktrace = ''.join(traceback.format_tb(tb))
             kwargs["stacktrace"] = stacktrace
         self.send(
-            metric_name, message=message, ex_type=ex_type, location=location, **kwargs,
+            metric_name,
+            message=message,
+            ex_type=ex_type,
+            location=location,
+            **kwargs,
         )

--- a/mite/stats.py
+++ b/mite/stats.py
@@ -149,7 +149,7 @@ _MITE_STATS = [
     Counter(
         name='mite_journey_error_total',
         matcher=matcher_by_type('error', 'exception'),
-        extractor=extractor('test journey transaction location message'.split()),
+        extractor=extractor('test journey transaction location ex_type message'.split()),
     ),
     Counter(
         name='mite_transaction_total',

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -43,7 +43,7 @@ async def test_runner_exception():
         if message['type'] == 'exception':
             print(message)
             assert message['ex_type'] == "Exception"
-            assert message['message'] == "test"
+            assert message['message'] == "Exception: test"
             break
     else:
         assert False, "Exception message was not sent"
@@ -65,7 +65,7 @@ async def test_runner_mite_error():
     for message in sender.messages:
         if message['type'] == 'error':
             print(message)
-            assert message['message'] == "test"
+            assert message['message'] == "mite.exceptions.MiteError: test"
             break
     else:
         assert False, "Exception message was not sent"


### PR DESCRIPTION
- a better way of generating more accurate error location info
- a better way of converting exceptions to strings.
  `str(KeyError("foo")) == "foo"`, which is less than optimal
- remove a mutable default kwarg