### PR TITLE
Remove root transaction

### DIFF
--- a/mite/context.py
+++ b/mite/context.py
@@ -4,22 +4,10 @@ import time
 import traceback
 from contextlib import asynccontextmanager
 from itertools import count
-from pathlib import PurePath
 
 from .exceptions import MiteError
 
 logger = logging.getLogger(__name__)
-
-_HERE = PurePath(__file__).parent
-_MITE_HTTP = _HERE.parent / "mite_http"
-# FIXME: if the mite_http module was installed at mite.http, then we could
-# omit this hack, and just use the (single) directory of the mite library for
-# the checks.  But that would require a change in the way we package mite,
-# which we might or might not ultimately want.  See also:
-# https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
-# Further FIXME: add the other built-in mite modules to the list of paths to
-# exclude
-_MITE_LIB_PATHS = {str(p) for p in (_HERE, _MITE_HTTP)}
 
 
 def _tb_format_location(tb):

--- a/mite/runner.py
+++ b/mite/runner.py
@@ -199,11 +199,10 @@ class Runner:
         )
         journey = spec_import_cached(journey_spec)
         try:
-            async with context.transaction('__root__'):
-                if args is None:
-                    await journey(context)
-                else:
-                    await journey(context, *args)
+            if args is None:
+                await journey(context)
+            else:
+                await journey(context, *args)
         except Exception as e:
             if not getattr(e, "handled", False):
                 if self._debug:


### PR DESCRIPTION
With the new nested txn names, we're getting `__root__ ::` prepended to each transaction.  This is one way of solving that.  It changes the semantics of what transactions are, but none of our code relies on there being an outer wrapper transaction (or at least it should not...).  If a user of mite wants a wrapper transaction, that seems like something they can implement themselves through a mechanism similar to our `@legacy_journey` wrapper.

I'm still unsure of whether this is the right solution though...the other alternative would be to add some special-case logic to context.py so that we don't nest the txn name if the parent txn is `__root__`.  Thoughts welcome...

PS I've cheekily snuck an unrelated fix onto this branch in context.py, just cleaning up some no-longer-used variables.  But the change discussed above is in runner.py.