### PR TITLE
Enhanced --debugging capability

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,4 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 known_first_party=_acurl
-known_third_party = aio_pika,altair,bs4,docopt,flask,ipdb,jinja2,mocks,msgpack,nanomsg,pandas,pkg_resources,psutil,pytest,pytest_httpserver,sanic,selenium,setuptools,ujson,uvloop,websockets,werkzeug,zmq
+known_third_party = aio_pika,altair,bs4,docopt,flask,jinja2,mocks,msgpack,nanomsg,pandas,pkg_resources,psutil,pytest,pytest_httpserver,sanic,selenium,setuptools,ujson,uvloop,websockets,werkzeug,zmq

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ before running mite. Python's built-in [pdb](https://docs.python.org/3/library/p
 debugger is invoked by default, but this can be changed to use, say, the
 [ipdb debugger](https://github.com/gotcha/ipdb):
 
-```pip install ipdb
+```
+pip install ipdb
 export PYTHONBREAKPOINT=ipdb.set_trace
 ```
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,15 @@ MITE_CONF_test_msg="Hello from mite" mite journey test mite.example:journey mite
 ```
 
 If something goes wrong, adding the `--debugging` flag to this command
-will drop into an [ipdb debugger](https://github.com/gotcha/ipdb) session.
+will drop excution into a debug session. The choice of debugger used can be
+managed by setting the [`PYTHONBREAKPOINT` environment variable](https://www.python.org/dev/peps/pep-0553/#environment-variable)
+before running mite. Python's built-in [pdb](https://docs.python.org/3/library/pdb.html))
+debugger is invoked by default, but this can be changed to use, say, the
+[ipdb debugger](https://github.com/gotcha/ipdb):
+
+```pip install ipdb
+export PYTHONBREAKPOINT=ipdb.set_trace
+```
 
 ### Run the scenario
 

--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -35,7 +35,7 @@ Examples:
 Options:
     -h --help                         Show this screen
     --version                         Show version
-    --debugging                       Drop into IPDB on journey error and exit
+    --debugging                       Drop into debugger (pdb) on journey error and exit. See PYTHONBREAKPOINT for debugger selection
     --log-level=LEVEL                 Set logger level, one of DEBUG, INFO, WARNING, ERROR, CRITICAL [default: INFO]
     --config=CONFIG_SPEC              Set a config loader to a callable loaded via a spec [default: mite.config:default_config_loader]
     --add-to-config=NEW_VALUE         Add a key:value to the config map, in addition to what's loaded from a file

--- a/mite/context.py
+++ b/mite/context.py
@@ -84,9 +84,7 @@ class Context:
             else:
                 self._send_exception("exception", e, include_stacktrace=True)
             if self._debug:  # pragma: no cover
-                import ipdb
-
-                ipdb.post_mortem()
+                breakpoint()
                 sys.exit(1)
             else:
                 e.handled = True

--- a/mite/runner.py
+++ b/mite/runner.py
@@ -3,8 +3,6 @@ import functools
 import logging
 from itertools import count
 
-import ipdb
-
 from .context import Context
 from .utils import spec_import
 
@@ -207,6 +205,6 @@ class Runner:
         except Exception as e:
             if not getattr(e, "handled", False):
                 if self._debug:
-                    ipdb.set_trace()
+                    breakpoint()
                     raise
         return scenario_id, scenario_data_id

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ install_requires =
     bs4
     docopt
     flask
-    ipdb
     msgpack
     nanomsg
     pyzmq


### PR DESCRIPTION
Uncoupled mite's dependency upon the ipdb debugger and therefore also decoupled from a direct dependency upon IPython.

This pull pull request:

- Removes references to and dependencies upon ipdb.
- Replaces calls to `ipdb.post_mortem()` and `ipdb.set_trace()` with a call to Python 3.7's `breakpoint()` built-in.
- Documents the new behaviour of mite's `--debugging` flag.

If mite is executed using the `--debugging` flag, then Python's default debugger, pdb, is invoked unless `PYTHONBREAKPOINT` has been set to override this behaviour.

The ipdb debugger can still be used for debugging, but it must first be explicitly pip-installed (along with its dependencies, such as IPython).