### PR TITLE
 Fix for request cookies not returning session cookies

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,4 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 known_first_party=_acurl
-known_third_party = aio_pika,altair,bs4,docopt,flask,ipdb,jinja2,mocks,msgpack,nanomsg,pandas,pkg_resources,psutil,pytest,pytest_httpserver,sanic,selenium,setuptools,ujson,uvloop,websockets,werkzeug,zmq
+known_third_party = aio_pika,altair,bs4,docopt,flask,helpers,ipdb,jinja2,mocks,msgpack,nanomsg,pandas,pkg_resources,psutil,pytest,pytest_httpserver,sanic,selenium,setuptools,ujson,uvloop,websockets,werkzeug,zmq

--- a/acurl/acurl/__init__.py
+++ b/acurl/acurl/__init__.py
@@ -21,11 +21,11 @@ class RequestError(Exception):
     pass
 
 
-_FALSE_TRUE = ['FALSE', 'TRUE']
+_FALSE_TRUE = ["FALSE", "TRUE"]
 
 
 class Cookie:
-    __slots__ = '_http_only _domain _include_subdomains _path _is_secure _expiration _name _value'.split()
+    __slots__ = "_http_only _domain _include_subdomains _path _is_secure _expiration _name _value".split()
 
     def __init__(
         self,
@@ -104,42 +104,42 @@ class Cookie:
     def format(self):
         bits = []
         if self.http_only:
-            bits.append('#HttpOnly_')
+            bits.append("#HttpOnly_")
         bits.append(self.domain)
-        bits.append('\t')
+        bits.append("\t")
         bits.append(_FALSE_TRUE[self.include_subdomains])
-        bits.append('\t')
+        bits.append("\t")
         bits.append(self.path)
-        bits.append('\t')
+        bits.append("\t")
         bits.append(_FALSE_TRUE[self.is_secure])
-        bits.append('\t')
+        bits.append("\t")
         bits.append(str(self.expiration))
-        bits.append('\t')
+        bits.append("\t")
         bits.append(self.name)
-        bits.append('\t')
+        bits.append("\t")
         bits.append(self.value)
-        return ''.join(bits)
+        return "".join(bits)
 
 
 def parse_cookie_string(cookie_string):
     cookie_string = cookie_string.strip()
-    if cookie_string.startswith('#HttpOnly_'):
+    if cookie_string.startswith("#HttpOnly_"):
         http_only = True
         cookie_string = cookie_string[10:]
     else:
         http_only = False
-    parts = cookie_string.split('\t')
+    parts = cookie_string.split("\t")
     if len(parts) == 6:
         domain, include_subdomains, path, is_secure, expiration, name = parts
-        value = ''
+        value = ""
     else:
         domain, include_subdomains, path, is_secure, expiration, name, value = parts
     return Cookie(
         http_only,
         domain,
-        include_subdomains == 'TRUE',
+        include_subdomains == "TRUE",
         path,
-        is_secure == 'TRUE',
+        is_secure == "TRUE",
         int(expiration),
         name,
         value,
@@ -165,7 +165,7 @@ def session_cookie_for_url(
 ):
     scheme, netloc, path, params, query, fragment = urlparse(url)
     if not include_url_path:
-        path = '/'
+        path = "/"
     # TODO do we need to sanitize netloc for IP and ports?
     return Cookie(
         http_only,
@@ -184,7 +184,7 @@ def _cookie_seq_to_cookie_dict(cookie_list):
 
 
 class Request:
-    __slots__ = '_method _url _header_seq _cookie_tuple _auth _data _cert _session_cookies'.split()
+    __slots__ = "_method _url _header_seq _cookie_tuple _auth _data _cert _session_cookies".split()
 
     def __init__(self, method, url, header_seq, cookie_seq, auth, data, cert, session):
         self._method = method
@@ -197,7 +197,7 @@ class Request:
         self._session_cookies = tuple(
             c
             for c in session.get_cookie_list()
-            if urlparse(self._url).hostname.lower() == c._domain
+            if urlparse(self._url).hostname.lower() == c._domain.lower()
         )
 
     @property
@@ -210,7 +210,7 @@ class Request:
 
     @property
     def headers(self):
-        return dict(header.split(': ', 1) for header in self._header_seq)
+        return dict(header.split(": ", 1) for header in self._header_seq)
 
     @property
     def cookies(self):
@@ -253,7 +253,7 @@ class Request:
 
 
 class Response:
-    __slots__ = '_req _resp _start_time _redirect_url _prev _body _text _header _headers_tuple _headers _encoding _json'.split()
+    __slots__ = "_req _resp _start_time _redirect_url _prev _body _text _header _headers_tuple _headers _encoding _json".split()
 
     def __init__(self, req, resp, start_time):
         self._req = req
@@ -276,7 +276,7 @@ class Response:
 
     @property
     def redirect_url(self):
-        if not hasattr(self, '_redirect_url'):
+        if not hasattr(self, "_redirect_url"):
             self._redirect_url = self._resp.get_redirect_url()
         return self._redirect_url
 
@@ -332,31 +332,31 @@ class Response:
     @property
     def history(self):
         result = []
-        cur = getattr(self, '_prev', None)
+        cur = getattr(self, "_prev", None)
         while cur is not None:
             result.append(cur)
-            cur = getattr(cur, '_prev', None)
+            cur = getattr(cur, "_prev", None)
         result.reverse()
         return result
 
     @property
     def body(self):
-        if not hasattr(self, '_body'):
-            self._body = b''.join(self._resp.get_body())
+        if not hasattr(self, "_body"):
+            self._body = b"".join(self._resp.get_body())
         return self._body
 
     @property
     def encoding(self):
-        if not hasattr(self, '_encoding'):
+        if not hasattr(self, "_encoding"):
             if (
-                'Content-Type' in self.headers
-                and 'charset=' in self.headers['Content-Type']
+                "Content-Type" in self.headers
+                and "charset=" in self.headers["Content-Type"]
             ):
                 self._encoding = (
-                    self.headers['Content-Type'].split('charset=')[-1].split()[0]
+                    self.headers["Content-Type"].split("charset=")[-1].split()[0]
                 )
             else:
-                self._encoding = 'latin1'
+                self._encoding = "latin1"
         return self._encoding
 
     # TODO: why do we allow setter?
@@ -366,40 +366,40 @@ class Response:
 
     @property
     def text(self):
-        if not hasattr(self, '_text'):
+        if not hasattr(self, "_text"):
             self._text = self.body.decode(self.encoding)
         return self._text
 
     def json(self):
-        if not hasattr(self, '_json'):
+        if not hasattr(self, "_json"):
             self._json = ujson.loads(self.text)
         return self._json
 
     @property
     def headers(self):
-        if not hasattr(self, '_headers'):
+        if not hasattr(self, "_headers"):
             headers = CaseInsensitiveDefaultDict(list)
             for k, v in self.headers_tuple:
                 headers[k].append(v)
             self._headers = CaseInsensitiveDict()
             for k in headers:
-                self._headers[k] = ', '.join(headers[k])
+                self._headers[k] = ", ".join(headers[k])
         return self._headers
 
     # TODO: is this part of the request api?
     @property
     def headers_tuple(self):
-        if not hasattr(self, '_headers_tuple'):
+        if not hasattr(self, "_headers_tuple"):
             self._headers_tuple = tuple(
-                tuple(l.split(': ', 1)) for l in self.header.split('\r\n')[1:-2]
+                tuple(l.split(": ", 1)) for l in self.header.split("\r\n")[1:-2]
             )
         return self._headers_tuple
 
     # TODO: is this part of the request api?
     @property
     def header(self):
-        if not hasattr(self, '_header'):
-            self._header = b''.join(self._resp.get_header()).decode('ascii')
+        if not hasattr(self, "_header"):
+            self._header = b"".join(self._resp.get_header()).decode("ascii")
         return self._header
 
 
@@ -410,22 +410,22 @@ class Session:
         self._response_callback = None
 
     async def get(self, url, **kwargs):
-        return await self.request('GET', url, **kwargs)
+        return await self.request("GET", url, **kwargs)
 
     async def put(self, url, **kwargs):
-        return await self.request('PUT', url, **kwargs)
+        return await self.request("PUT", url, **kwargs)
 
     async def post(self, url, **kwargs):
-        return await self.request('POST', url, **kwargs)
+        return await self.request("POST", url, **kwargs)
 
     async def delete(self, url, **kwargs):
-        return await self.request('DELETE', url, **kwargs)
+        return await self.request("DELETE", url, **kwargs)
 
     async def head(self, url, **kwargs):
-        return await self.request('HEAD', url, **kwargs)
+        return await self.request("HEAD", url, **kwargs)
 
     async def options(self, url, **kwargs):
-        return await self.request('OPTIONS', url, **kwargs)
+        return await self.request("OPTIONS", url, **kwargs)
 
     async def request(
         self,
@@ -444,14 +444,14 @@ class Session:
         cookies = dict(cookies)
         if json is not None:
             if data is not None:
-                raise ValueError('use only one or none of data or json')
+                raise ValueError("use only one or none of data or json")
             data = ujson.dumps(json)
-            if 'Content-Type' not in headers:
-                headers['Content-Type'] = 'application/json'
+            if "Content-Type" not in headers:
+                headers["Content-Type"] = "application/json"
 
         # FIXME: probably need to do some escaping if one of the values has
         # newlines in it...
-        headers_list = ['%s: %s' % i for i in headers.items()]
+        headers_list = ["%s: %s" % i for i in headers.items()]
         cookie_list = [session_cookie_for_url(url, k, v) for k, v in cookies.items()]
 
         return await self._request(
@@ -507,10 +507,10 @@ class Session:
             and response.redirect_url is not None
         ):
             if remaining_redirects == 0:
-                raise RequestError('Max Redirects')
+                raise RequestError("Max Redirects")
             elif response.status_code in {301, 302, 303}:
                 redir_response = await self._request(
-                    'GET',
+                    "GET",
                     response.redirect_url,
                     header_tuple,
                     (),
@@ -541,8 +541,8 @@ class Session:
             # We pass in None instead of a future, bc the request will be done
             # synchronously
             None,
-            'GET',
-            '',
+            "GET",
+            "",
             headers=(),
             cookies=cookies,
             auth=None,
@@ -553,10 +553,10 @@ class Session:
         return result
 
     def erase_all_cookies(self):
-        self._dummy_request(('ALL',))
+        self._dummy_request(("ALL",))
 
     def erase_session_cookies(self):
-        self._dummy_request(('SESS',))
+        self._dummy_request(("SESS",))
 
     def get_cookie_list(self):
         resp = self._dummy_request(())

--- a/acurl/tests/helpers.py
+++ b/acurl/tests/helpers.py
@@ -1,0 +1,12 @@
+from unittest.mock import Mock
+
+import acurl
+
+
+def create_request(
+    method, url, headers=(), cookies=(), auth=None, data=None, cert=None, session=None
+):
+    if session is None:
+        session = Mock()
+        session.get_cookie_list.return_value = ()
+    return acurl.Request(method, url, headers, cookies, auth, data, cert, session)

--- a/acurl/tests/test_httpbin.py
+++ b/acurl/tests/test_httpbin.py
@@ -34,11 +34,11 @@ async def test_cookies():
 async def test_session_cookies():
     s = session()
     await s.get('https://httpbin.org/cookies/set?name=value')
-    cookie_list = await s.get_cookie_list()
+    cookie_list = s.get_cookie_list()
     assert len(cookie_list) == 1
     assert cookie_list[0].name == 'name'
-    await s.erase_all_cookies()
-    cookie_list = await s.get_cookie_list()
+    s.erase_all_cookies()
+    cookie_list = s.get_cookie_list()
     assert len(cookie_list) == 0
 
 

--- a/acurl/tests/test_request.py
+++ b/acurl/tests/test_request.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 import acurl
@@ -10,7 +12,7 @@ def session():
 
 def test_request_headers():
     r = acurl.Request(
-        "GET", "http://foo.com", ["Foo: bar", "Baz: quux"], [], None, None, None
+        "GET", "http://foo.com", ["Foo: bar", "Baz: quux"], [], None, None, None, None
     )
     assert "Foo" in r.headers
     assert r.headers["Foo"] == "bar"
@@ -19,19 +21,22 @@ def test_request_headers():
 
 
 def test_request_cookies():
+    session_mock = Mock()
+    session_mock.get_cookie_list.return_value = ()
     r = acurl.Request(
         "GET",
         "http://foo.com",
         [],  # headers
-        [
+        (
             acurl.parse_cookie_string(
                 "foo.com\tFALSE\t/bar\tFALSE\t0\tmy_cookie\tmy_value"
             ),
             acurl.parse_cookie_string("foo.com\tFALSE\t/bar\tFALSE\t0\tfoo\tbar"),
-        ],
+        ),
         None,  # auth
         None,  # data
         None,  # cert
+        session_mock,  # session
     )
     assert "my_cookie" in r.cookies
     assert r.cookies["my_cookie"] == "my_value"
@@ -44,4 +49,17 @@ async def test_request_cookies_from_previous(httpbin):
     s = session()
     await s.get(httpbin.url + '/cookies/set?name=value')
     r = await s.get(httpbin.url + "/get")
-    assert "name" in r.request.cookies
+    assert r.request.cookies == {"name": "value"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.slow
+async def test_request_cookies_from_previous_excludes_other_domains(httpbin):
+    s = session()
+    await s.get(httpbin.url + '/cookies/set?name=value')
+    # FIXME: we want to set a cookie for another domain.  There's no easy way
+    # to get another domain set up loally, so we (as an exception) go out to
+    # the network for this test.
+    await s.get("https://httpbin.org/cookies/set?foo=bar")
+    r = await s.get(httpbin.url + "/get")
+    assert r.request.cookies == {"name": "value"}

--- a/acurl/tests/test_request.py
+++ b/acurl/tests/test_request.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+from helpers import create_request
 
 import acurl
 
@@ -11,9 +12,7 @@ def session():
 
 
 def test_request_headers():
-    r = acurl.Request(
-        "GET", "http://foo.com", ["Foo: bar", "Baz: quux"], [], None, None, None, None
-    )
+    r = create_request("GET", "http://foo.com", headers=["Foo: bar", "Baz: quux"])
     assert "Foo" in r.headers
     assert r.headers["Foo"] == "bar"
     assert "Baz" in r.headers
@@ -23,20 +22,15 @@ def test_request_headers():
 def test_request_cookies():
     session_mock = Mock()
     session_mock.get_cookie_list.return_value = ()
-    r = acurl.Request(
+    r = create_request(
         "GET",
         "http://foo.com",
-        [],  # headers
-        (
+        cookies=(
             acurl.parse_cookie_string(
                 "foo.com\tFALSE\t/bar\tFALSE\t0\tmy_cookie\tmy_value"
             ),
             acurl.parse_cookie_string("foo.com\tFALSE\t/bar\tFALSE\t0\tfoo\tbar"),
         ),
-        None,  # auth
-        None,  # data
-        None,  # cert
-        session_mock,  # session
     )
     assert "my_cookie" in r.cookies
     assert r.cookies["my_cookie"] == "my_value"

--- a/acurl/tests/test_request.py
+++ b/acurl/tests/test_request.py
@@ -41,7 +41,7 @@ def test_request_cookies():
 @pytest.mark.asyncio
 async def test_request_cookies_from_previous(httpbin):
     s = session()
-    await s.get(httpbin.url + '/cookies/set?name=value')
+    await s.get(httpbin.url + "/cookies/set?name=value")
     r = await s.get(httpbin.url + "/get")
     assert r.request.cookies == {"name": "value"}
 
@@ -50,7 +50,7 @@ async def test_request_cookies_from_previous(httpbin):
 @pytest.mark.slow
 async def test_request_cookies_from_previous_excludes_other_domains(httpbin):
     s = session()
-    await s.get(httpbin.url + '/cookies/set?name=value')
+    await s.get(httpbin.url + "/cookies/set?name=value")
     # FIXME: we want to set a cookie for another domain.  There's no easy way
     # to get another domain set up loally, so we (as an exception) go out to
     # the network for this test.

--- a/acurl/tests/test_to_curl.py
+++ b/acurl/tests/test_to_curl.py
@@ -1,10 +1,16 @@
-from acurl import Request
-import acurl
+from unittest.mock import Mock
+
 import pytest
+
+import acurl
+from acurl import Request
+
+session_mock = Mock()
+session_mock.get_cookie_list.return_value = ()
 
 
 def test_to_curl():
-    r = Request("GET", "http://foo.com", (), (), None, None, None)
+    r = Request("GET", "http://foo.com", (), (), None, None, None, session_mock)
     assert r.to_curl() == "curl -X GET     http://foo.com"
 
 
@@ -17,6 +23,7 @@ def test_to_curl_headers():
         None,
         None,
         None,
+        session_mock,
     )
     assert (
         r.to_curl()
@@ -33,6 +40,7 @@ def test_to_curl_cookies():
         None,
         None,
         None,
+        session_mock,
     )
     assert r.to_curl() == "curl -X GET  --cookie 123=456   http://foo.com"
 
@@ -49,6 +57,7 @@ def test_to_curl_multiple_cookies():
         None,
         None,
         None,
+        session_mock,
     )
     assert r.to_curl() == "curl -X GET  --cookie '123=456;789=abc'   http://foo.com"
 
@@ -74,10 +83,13 @@ def test_to_curl_cookies_wrong_domain():
         None,
         None,
         None,
+        session_mock,
     )
     assert r.to_curl() == "curl -X GET http://foo.com"
 
 
 def test_to_curl_auth():
-    r = Request("GET", "http://foo.com", (), (), ("user", "pass"), None, None)
+    r = Request(
+        "GET", "http://foo.com", (), (), ("user", "pass"), None, None, session_mock
+    )
     assert r.to_curl() == "curl -X GET   --user user:pass  http://foo.com"

--- a/acurl/tests/test_to_curl.py
+++ b/acurl/tests/test_to_curl.py
@@ -1,29 +1,17 @@
-from unittest.mock import Mock
-
 import pytest
+from helpers import create_request
 
 import acurl
-from acurl import Request
-
-session_mock = Mock()
-session_mock.get_cookie_list.return_value = ()
 
 
 def test_to_curl():
-    r = Request("GET", "http://foo.com", (), (), None, None, None, session_mock)
+    r = create_request("GET", "http://foo.com")
     assert r.to_curl() == "curl -X GET     http://foo.com"
 
 
 def test_to_curl_headers():
-    r = Request(
-        "GET",
-        "http://foo.com",
-        ("Foo: bar", "My-Header: is-awesome"),
-        (),
-        None,
-        None,
-        None,
-        session_mock,
+    r = create_request(
+        "GET", "http://foo.com", headers=("Foo: bar", "My-Header: is-awesome")
     )
     assert (
         r.to_curl()
@@ -32,43 +20,32 @@ def test_to_curl_headers():
 
 
 def test_to_curl_cookies():
-    r = Request(
+    r = create_request(
         "GET",
         "http://foo.com",
-        (),
-        (acurl.Cookie(False, "foo.com", True, "/", False, 0, "123", "456"),),
-        None,
-        None,
-        None,
-        session_mock,
+        cookies=(acurl.Cookie(False, "foo.com", True, "/", False, 0, "123", "456"),),
     )
     assert r.to_curl() == "curl -X GET  --cookie 123=456   http://foo.com"
 
 
 def test_to_curl_multiple_cookies():
-    r = Request(
+    r = create_request(
         "GET",
         "http://foo.com",
-        (),
-        (
+        cookies=(
             acurl.Cookie(False, "foo.com", True, "/", False, 0, "123", "456"),
             acurl.Cookie(False, "foo.com", True, "/", False, 0, "789", "abc"),
         ),
-        None,
-        None,
-        None,
-        session_mock,
     )
     assert r.to_curl() == "curl -X GET  --cookie '123=456;789=abc'   http://foo.com"
 
 
 @pytest.mark.skip(reason="unimplemented")
 def test_to_curl_cookies_wrong_domain():
-    r = Request(
+    r = create_request(
         "GET",
         "http://foo.com",
-        (),
-        (
+        cookies=(
             acurl.Cookie(
                 False,
                 "bar.com",  # The domain doesn't match, the cookie should not be passed
@@ -80,16 +57,10 @@ def test_to_curl_cookies_wrong_domain():
                 "456",
             ),
         ),
-        None,
-        None,
-        None,
-        session_mock,
     )
     assert r.to_curl() == "curl -X GET http://foo.com"
 
 
 def test_to_curl_auth():
-    r = Request(
-        "GET", "http://foo.com", (), (), ("user", "pass"), None, None, session_mock
-    )
+    r = create_request("GET", "http://foo.com", auth=("user", "pass"))
     assert r.to_curl() == "curl -X GET   --user user:pass  http://foo.com"


### PR DESCRIPTION
 Fix for request cookies not returning session cookies

- Remove the cookie_list property on Request objects.  Itʼs not part of
  the requests API, and it raises thorny questions (should we really be
  returning a list?)  The underlying data is available on the
  `_cookie_tuple` property if someone really needs it.
- Make Requests store a copy of the session cookies when created.
  Thereʼs a bit of an issue here in that it causes us to do extra
  processing when every Request is created.  My first implementation
  idea was to store a reference to the session in the Request class and
  do the calculation in the cookie property – but since the session is
  mutable, that means the cookies could have changed in the mean time.
  So Iʼm not sure if I see an alternative to this....
- Make the session cookie manipulation methods on Session objects
  non-async
  - the python changes are incredibly straightforward
  - the C code requires a change so that if the `dummy` flag is set on a
    request, it does not go through the eventloop but the response
    object is returned directly.  (We may eventually want to do away
    with the returning of a Response object, and simply the flow to a
    greater degree...)

