### PR TITLE
add a test for a previously problematic multi-cookie case

### DIFF
--- a/cd-scripts/runTests.sh
+++ b/cd-scripts/runTests.sh
@@ -5,6 +5,8 @@ MY_VENV=$HOME/mite-tests
 python3.8 -m venv $MY_VENV
 . $MY_VENV/bin/activate
 
+pip install -U pip
+
 pip install -r requirements.txt || exit 1
 pip install -r dev-requirements.txt || exit 1
 

--- a/cd-scripts/runTests.sh
+++ b/cd-scripts/runTests.sh
@@ -2,7 +2,7 @@
 
 MY_VENV=$HOME/mite-tests
 
-python3.8 -m venv $MY_VENV
+python3.8 -m venv --system-site-packages $MY_VENV
 . $MY_VENV/bin/activate
 
 pip install -U pip


### PR DESCRIPTION
this came up in our idris testing; we had to hack around this by
inspecting headers directly.  now itʼs resolved through recent code
changes, but this test case proves (and maintains) that fix, so we can
take away the hack in our private test suite code