### PR TITLE
Selenium built in page load metrics and context manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ ENV/
 
 # Pycharm
 .idea/*
+.vscode/*
 
 # Jordan's add . moron protection
 recorder_data/

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -4,38 +4,38 @@ import time
 
 class MsgOutput:
     def __init__(self):
-        self._logger = logging.getLogger('MSG')
+        self._logger = logging.getLogger("MSG")
 
     def process_message(self, msg):
-        stacktrace = msg.pop('stacktrace', None)
+        stacktrace = msg.pop("stacktrace", None)
         if stacktrace and self._logger.isEnabledFor(logging.WARNING):
-            message = msg.pop('message', None)
-            ex_type = msg.pop('ex_type', None)
-            start = "[%s] %.6f" % (msg.pop('type', None), msg.pop('time', None))
-            end = ', '.join("%s=%r" % (k, v) for k, v in sorted(msg.items()))
+            message = msg.pop("message", None)
+            ex_type = msg.pop("ex_type", None)
+            start = "[%s] %.6f" % (msg.pop("type", None), msg.pop("time", None))
+            end = ", ".join("%s=%r" % (k, v) for k, v in sorted(msg.items()))
             self._logger.warning(
                 "%s %s\n%s: %s\n%s", start, end, ex_type, message, stacktrace
             )
         elif self._logger.isEnabledFor(logging.DEBUG):
-            start = "[%s] %.6f" % (msg.pop('type', None), msg.pop('time', None))
-            end = ', '.join("%s=%r" % (k, v) for k, v in sorted(msg.items()))
+            start = "[%s] %.6f" % (msg.pop("type", None), msg.pop("time", None))
+            end = ", ".join("%s=%r" % (k, v) for k, v in sorted(msg.items()))
             self._logger.debug("%s %s", start, end)
 
 
 class DebugMessageOutput:
     def __init__(self):
-        self._logger = logging.getLogger('Debug Logger')
+        self._logger = logging.getLogger("Debug Logger")
 
     def process_message(self, message):
         text = message.get("text")
-        if message.get('type') == "debug_console_message" and text:
+        if message.get("type") == "debug_console_message" and text:
             self._logger.info(text)
 
 
 class HttpStatsOutput:
     def __init__(self, period=2):
         self._period = period
-        self._logger = logging.getLogger('Http Stats')
+        self._logger = logging.getLogger("Http Stats")
         self._start_t = None
         self._req_total = 0
         self._req_recent = 0
@@ -63,9 +63,9 @@ class HttpStatsOutput:
         return self._error_total
 
     def process_message(self, message):
-        if 'type' not in message:
+        if "type" not in message:
             return
-        msg_type = message['type']
+        msg_type = message["type"]
         t = time.time()
         if self._start_t is None:
             self._start_t = t
@@ -73,11 +73,11 @@ class HttpStatsOutput:
             dt = t - self._start_t
             self._resp_time_recent.sort()
             self._logger.info(
-                'Total> #Reqs:%d #Errs:%d', self._req_total, self._error_total
+                "Total> #Reqs:%d #Errs:%d", self._req_total, self._error_total
             )
             self._logger.info(
-                'Last %d Secs> #Reqs:%d #Errs:%d Req/S:%.1f min:%s 25%%:%s 50%%:%s '
-                '75%%:%s 90%%:%s 99%%:%s 99.9%%:%s 99.99%%:%s max:%s',
+                "Last %d Secs> #Reqs:%d #Errs:%d Req/S:%.1f min:%s 25%%:%s 50%%:%s "
+                "75%%:%s 90%%:%s 99%%:%s 99.9%%:%s 99.99%%:%s max:%s",
                 self._period,
                 self._req_recent,
                 self._error_recent,
@@ -96,14 +96,18 @@ class HttpStatsOutput:
             del self._resp_time_recent[:]
             self._req_recent = 0
             self._error_recent = 0
-        if msg_type == 'http_metrics':
-            self._resp_time_recent.append(message['total_time'])
+        if msg_type == "http_metrics":
+            self._resp_time_recent.append(message["total_time"])
             self._req_total += 1
             self._req_recent += 1
-        elif msg_type == 'http_selenium_metrics':
-            self._resp_time_recent.append(message['total_time'])
+        elif msg_type == "http_selenium_page_load_metrics":
+            self._resp_time_recent.append(message["total_time"])
             self._req_total += 1
             self._req_recent += 1
-        elif msg_type in ('error', 'exception'):
+        elif msg_type == "http_selenium_network_resource_metrics":
+            self._resp_time_recent.append(message["total_time"])
+            self._req_total += 1
+            self._req_recent += 1
+        elif msg_type in ("error", "exception"):
             self._error_total += 1
             self._error_recent += 1

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -96,15 +96,11 @@ class HttpStatsOutput:
             del self._resp_time_recent[:]
             self._req_recent = 0
             self._error_recent = 0
-        if msg_type == "http_metrics":
-            self._resp_time_recent.append(message["total_time"])
-            self._req_total += 1
-            self._req_recent += 1
-        elif msg_type == "http_selenium_page_load_metrics":
-            self._resp_time_recent.append(message["total_time"])
-            self._req_total += 1
-            self._req_recent += 1
-        elif msg_type == "http_selenium_network_resource_metrics":
+        if msg_type in {
+            "http_metrics",
+            "http_selenium_page_load_metrics",
+            "http_selenium_network_resource_metrics",
+        }:
             self._resp_time_recent.append(message["total_time"])
             self._req_total += 1
             self._req_recent += 1

--- a/mite_selenium/__init__.py
+++ b/mite_selenium/__init__.py
@@ -154,7 +154,7 @@ class _SeleniumWrapper:
     def get_js_metrics_context(self):
         return JsMetricsContext(self)
 
-    def wait(self, locator, timeout=5):
+    def wait_for_element(self, locator, timeout=5):
         try:
             return WebDriverWait(self._remote, timeout).until(
                 EC.presence_of_element_located(locator)
@@ -165,7 +165,10 @@ class _SeleniumWrapper:
             ) from te
 
     def find_element(self, locator):
-        return self.wait(locator, 2)
+        return self.wait_for_element(locator, 2)
+
+    def implicit_wait(self, timeout):
+        self._remote.implicitly_wait(timeout)
 
 
 class JsMetricsContext:
@@ -173,11 +176,11 @@ class JsMetricsContext:
         self._browser = browser
         self._results = None
 
-    async def __aenter__(self):
-        self._browser._clear_resource_timings()
+        async def __aenter__(self):
+            self._browser._clear_resource_timings()
 
-    async def __aexit__(self, exc_type, exc, tb):
-        self._results = self._browser._retrieve_javascript_metrics()
+        async def __aexit__(self, exc_type, exc, tb):
+            self._results = self._browser._retrieve_javascript_metrics()
 
 
 @asynccontextmanager

--- a/mite_selenium/__init__.py
+++ b/mite_selenium/__init__.py
@@ -107,7 +107,7 @@ class _SeleniumWrapper:
                 "total_time": timings["duration"],
             }
             self._context.send(
-                "http_selenium_page_load_metrics",
+                "selenium_page_load_metrics",
                 **self._extract_and_convert_metrics_to_seconds(metrics),
             )
 
@@ -122,7 +122,7 @@ class _SeleniumWrapper:
 
     def _extract_and_convert_metrics_to_seconds(self, metrics):
         converted_metrics = dict()
-        non_time_based_metrics = ["page_weight"]
+        non_time_based_metrics = ["page_weight", "resource_path"]
         for k, v in metrics.items():
             if k not in non_time_based_metrics:
                 converted_metrics[k] = self._convert_ms_to_seconds(v)

--- a/mite_selenium/__init__.py
+++ b/mite_selenium/__init__.py
@@ -143,7 +143,6 @@ class _SeleniumWrapper:
             return []
 
     def _clear_resource_timings(self):
-        breakpoint()
         self._remote.execute_script("performance.clearResourceTimings()")
 
     def get(self, url):

--- a/mite_selenium/__init__.py
+++ b/mite_selenium/__init__.py
@@ -176,11 +176,11 @@ class JsMetricsContext:
         self._browser = browser
         self._results = None
 
-        async def __aenter__(self):
-            self._browser._clear_resource_timings()
+    async def __aenter__(self):
+        self._browser._clear_resource_timings()
 
-        async def __aexit__(self, exc_type, exc, tb):
-            self._results = self._browser._retrieve_javascript_metrics()
+    async def __aexit__(self, exc_type, exc, tb):
+        self._results = self._browser._retrieve_javascript_metrics()
 
 
 @asynccontextmanager

--- a/mite_selenium/__init__.py
+++ b/mite_selenium/__init__.py
@@ -2,7 +2,10 @@ import logging
 from contextlib import asynccontextmanager
 
 from selenium.webdriver import Remote
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
 
+from mite.exceptions import MiteError
 from mite.utils import spec_import
 
 logger = logging.getLogger(__name__)
@@ -27,7 +30,7 @@ class _SeleniumWrapper:
         self._options = self._spec_import_if_none("webdriver_options")
 
         # Required param
-        self._capabilities = self._context.config.get('webdriver_capabilities')
+        self._capabilities = self._context.config.get("webdriver_capabilities")
         if not type(self._capabilities) == dict:
             self._capabilities = spec_import(self._capabilities)
 
@@ -37,8 +40,9 @@ class _SeleniumWrapper:
             value = spec_import(value)
         return value
 
-    def start(self):
-        self._context.browser = Remote(
+    def _start(self):
+        self._context.browser = self
+        self._remote = Remote(
             desired_capabilities=self._capabilities,
             command_executor=self._command_executor,
             browser_profile=self._browser_profile,
@@ -48,45 +52,142 @@ class _SeleniumWrapper:
             options=self._options,
         )
 
-    def stop(self):
-        self._context.browser.close()
+    def _stop(self):
+        self._remote.close()
+
+    def _browser_has_timing_capabilities(self):
+        return self._remote.capabilities["browserName"] == "chrome"
+
+    def _is_using_tls(self, name):
+        return name.startswith("https")
+
+    def _get_tls_timing(self, timings):
+        if self._is_using_tls(timings["name"]):
+            return timings["connectEnd"] - timings["secureConnectionStart"]
+        else:
+            logger.info("Secure TLS connection not used, defaulting tls_time to 0")
+            return 0
+
+    def _get_tcp_timing(self, timings):
+        if self._is_using_tls(timings["name"]):
+            return timings["secureConnectionStart"] - timings["connectStart"]
+        else:
+            return timings["connectEnd"] - timings["connectStart"]
+
+    def _send_page_load_metrics(self):
+        if self._browser_has_timing_capabilities():
+            performance_entries = self._remote.execute_script(
+                "return performance.getEntriesByType('navigation')"
+            )
+
+            timings = self._extract_first_entry(performance_entries)
+            if timings is None:
+                return
+
+            protocol = timings["nextHopProtocol"]
+            if protocol != "http/1.1":
+                logger.warning(
+                    f"Timings may be inaccurate as protocol is not http/1.1: {protocol}"
+                )
+            metrics = {
+                "dns_lookup_time": timings["domainLookupEnd"]
+                - timings["domainLookupStart"],
+                "dom_interactive": timings["domInteractive"],
+                "js_onload_time": timings["domContentLoadedEventEnd"]
+                - timings["domContentLoadedEventStart"],
+                "page_weight": timings["transferSize"],
+                "render_time": timings["domInteractive"] - timings["responseEnd"],
+                "tcp_time": self._get_tcp_timing(timings),
+                "time_to_first_byte": timings["responseStart"] - timings["connectEnd"],
+                "time_to_interactive": timings["domInteractive"]
+                - timings["requestStart"],
+                "time_to_last_byte": timings["responseEnd"] - timings["connectEnd"],
+                "tls_time": self._get_tls_timing(timings),
+                "total_time": timings["duration"],
+            }
+            self._context.send(
+                "http_selenium_page_load_metrics",
+                **self._extract_and_convert_metrics_to_seconds(metrics),
+            )
+
+    def _extract_first_entry(self, entries):
+        if len(entries) != 1:
+            logger.error(
+                f"Performance entries did not return the expected count: expected 1 - actual {len(entries)}"
+            )
+            return
+        else:
+            return entries[0]
+
+    def _extract_and_convert_metrics_to_seconds(self, metrics):
+        converted_metrics = dict()
+        non_time_based_metrics = ["page_weight"]
+        for k, v in metrics.items():
+            if k not in non_time_based_metrics:
+                converted_metrics[k] = self._convert_ms_to_seconds(v)
+            else:
+                converted_metrics[k] = v
+        return converted_metrics
+
+    def _convert_ms_to_seconds(self, value_ms):
+        try:
+            return value_ms / 1000
+        except Exception:
+            return value_ms
+
+    def _retrieve_javascript_metrics(self):
+        try:
+            return self._remote.execute_script(
+                "return performance.getEntriesByType('resource')"
+            )
+        except Exception:
+            logger.error("Failed to retrieve resource performance entries")
+            return []
+
+    def _clear_resource_timings(self):
+        self._remote.execute_script("performance.clearResourceTimings()")
+
+    def get(self, url):
+        self._remote.get(url)
+        self._send_page_load_metrics()
+
+    def get_js_metrics_context(self):
+        return JsMetricsContext(self)
+
+    def wait(self, locator, timeout=5):
+        try:
+            return WebDriverWait(self._remote, timeout).until(
+                EC.presence_of_element_located(locator)
+            )
+        except Exception as te:
+            raise MiteError(
+                f"Timed out trying to find element '{locator}' in the dom"
+            ) from te
+
+    def find_element(self, locator):
+        return self.wait(locator, 2)
 
 
-def send_selenium_times(context):
-    """Maybe would probably need more error handling
-    if somebody tried to use with an incompatible browser"""
-    if context.browser.capabilities['browserName'] != 'chrome':
-        logger.warning(
-            'Timing metrics in %s are not currently supported',
-            context.browser.capabilities['browserName'],
-        )
-        return
+class JsMetricsContext:
+    def __init__(self, browser):
+        self._browser = browser
+        self._results = None
 
-    timings = context.browser.execute_script(
-        'return performance.getEntriesByType("navigation")'
-    )[0]
-    context.send(
-        "http_selenium_metrics",
-        dom_complete=timings["domComplete"],
-        dom_interactive=timings["domInteractive"],
-        transfer_size=timings["transferSize"],
-        transfer_start_timings=["requestStart"],
-        tls_time=timings["secureConnectionStart"],
-        dns_time=timings["domainLookupEnd"],
-        connect_time=timings["connectEnd"],
-        total_time=timings["duration"],
-        effective_url=timings["name"],
-    )
+    async def __aenter__(self):
+        self._browser._clear_resource_timings()
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self._results = self._browser._retrieve_javascript_metrics()
 
 
 @asynccontextmanager
 async def _selenium_context_manager(context):
     try:
         sw = _SeleniumWrapper(context)
-        sw.start()
+        sw._start()
         yield
     finally:
-        sw.stop()
+        sw._stop()
 
 
 def mite_selenium(func):

--- a/mite_selenium/stats.py
+++ b/mite_selenium/stats.py
@@ -1,15 +1,60 @@
 from mite.stats import Counter, Histogram, extractor, matcher_by_type
 
+_PAGE_LOAD_METRICS = [
+    ("dns_lookup_time", "seconds"),
+    ("dom_interactive", "seconds"),
+    ("js_onload_time", "seconds"),
+    ("page_weight", "bytes"),
+    ("render_time", "seconds"),
+    ("tcp_time", "seconds"),
+    ("tcp_time", "seconds"),
+    ("time_to_first_byte", "seconds"),
+    ("time_to_interactive", "seconds"),
+    ("time_to_last_byte", "seconds"),
+    ("tls_time", "seconds"),
+    ("total_time", "seconds"),
+]
+
+_NETWORK_RESOURCE_METRICS = [
+    ("dns_lookup_time", "seconds"),
+    ("page_weight", "bytes"),
+    ("tcp_time", "seconds"),
+    ("time_to_first_byte", "seconds"),
+    ("time_to_last_byte", "seconds"),
+    ("tls_time", "seconds"),
+    ("total_time", "seconds"),
+]
+
+
+def build_metrics(metrics, matcher, labels):
+    histograms = []
+    print(metrics)
+    for metric, unit in metrics:
+        bins = [0.0001, 0.001, 0.01, 0.05, 0.1, 0.2, 0.4, 0.8, 1, 2, 4, 8, 16, 32, 64]
+        if unit == "bytes":
+            bins = [b * 1000 for b in bins]
+
+        histograms.append(
+            Histogram(
+                name=f"mite_{matcher}_{metric}_{unit}",
+                matcher=matcher_by_type(f"{matcher}_metrics"),
+                extractor=extractor(labels, metric),
+                bins=bins,
+            )
+        )
+    return histograms
+
+
 STATS = (
-    Histogram(
-        'mite_http_selenium_response_time_seconds',
-        matcher_by_type('http_selenium_metrics'),
-        extractor=extractor(['transaction'], 'total_time'),
-        bins=[0.0001, 0.001, 0.01, 0.05, 0.1, 0.2, 0.4, 0.8, 1, 2, 4, 8, 16, 32, 64],
-    ),
     Counter(
-        'mite_http_selenium_response_total',
-        matcher_by_type('http_selenium_metrics'),
-        extractor('test journey transaction'.split()),
+        "mite_http_selenium_response_total",
+        matcher_by_type("http_selenium_page_load_metrics"),
+        extractor("test journey transaction".split()),
+    ),
+    *build_metrics(_PAGE_LOAD_METRICS, "http_selenium_page_load", ["transaction"]),
+    *build_metrics(
+        _NETWORK_RESOURCE_METRICS,
+        "http_selenium_network_resource",
+        ["transaction", "resource_path"],
     ),
 )

--- a/mite_selenium/stats.py
+++ b/mite_selenium/stats.py
@@ -50,7 +50,7 @@ STATS = (
         matcher_by_type("http_selenium_page_load_metrics"),
         extractor("test journey transaction".split()),
     ),
-    *build_metrics(_PAGE_LOAD_METRICS, "http_selenium_page_load", ["transaction"]),
+    *build_metrics(_PAGE_LOAD_METRICS, "selenium_page_load", ["transaction"]),
     *build_metrics(
         _NETWORK_RESOURCE_METRICS,
         "http_selenium_network_resource",

--- a/mite_selenium/stats.py
+++ b/mite_selenium/stats.py
@@ -28,7 +28,6 @@ _NETWORK_RESOURCE_METRICS = [
 
 def build_metrics(metrics, matcher, labels):
     histograms = []
-    print(metrics)
     for metric, unit in metrics:
         bins = [0.0001, 0.001, 0.01, 0.05, 0.1, 0.2, 0.4, 0.8, 1, 2, 4, 8, 16, 32, 64]
         if unit == "bytes":

--- a/mite_selenium/stats.py
+++ b/mite_selenium/stats.py
@@ -46,8 +46,8 @@ def build_metrics(metrics, matcher, labels):
 
 STATS = (
     Counter(
-        "mite_http_selenium_response_total",
-        matcher_by_type("http_selenium_page_load_metrics"),
+        "mite_selenium_response_total",
+        matcher_by_type("selenium_page_load_metrics"),
         extractor("test journey transaction".split()),
     ),
     *build_metrics(_PAGE_LOAD_METRICS, "selenium_page_load", ["transaction"]),

--- a/test/mocks/mock_selenium.py
+++ b/test/mocks/mock_selenium.py
@@ -1,6 +1,7 @@
-"""setup of webdriver using wrapper  uses spec import for the args,
-
-so this provides a path where they can be imported from"""
+"""
+Setup of webdriver using wrapper uses spec import for the args,
+so this provides a path where they can be imported from
+"""
 
 
 # Current tests don't care about spinning up a real webdriver so

--- a/test/test_prometheus_mite.py
+++ b/test/test_prometheus_mite.py
@@ -110,3 +110,25 @@ class TestHistogram:
         foo_sum{bar="one",baz="two"} 4.000000
         foo_count{bar="one",baz="two"} 2"""
         )
+
+    def test_histogram_format_with_empty_bin_count(self):
+        test_message = {
+            "name": "foo",
+            "labels": ("bar", "baz"),
+            "bin_counts": {},
+            "sums": {("one", "two"): 5},
+            "total_counts": {("one", "two"): 1},
+            "bins": (1, 2, 3),
+        }
+        h = Histogram("foo", test_message)
+        f = h.format()
+        assert f == dedent(
+            """\
+        # TYPE foo histogram
+        foo_bucket{bar="one",baz="two",le="1.000000"} 0
+        foo_bucket{bar="one",baz="two",le="2.000000"} 0
+        foo_bucket{bar="one",baz="two",le="3.000000"} 0
+        foo_bucket{bar="one",baz="two",le="+Inf"} 1
+        foo_sum{bar="one",baz="two"} 5.000000
+        foo_count{bar="one",baz="two"} 1"""
+        )

--- a/test/test_webdriver.py
+++ b/test/test_webdriver.py
@@ -60,17 +60,17 @@ def test_webdriver_start_stop(MockRemote):
     context = MockContext()
     context.config = DICT_CAPABILITIES_CONFIG
     wrapper = _SeleniumWrapper(context)
-    wrapper.start()
+    wrapper._start()
     MockRemote.assert_called_with(
         browser_profile=None,
-        command_executor='http://127.0.0.1:4444/wd/hub',
-        desired_capabilities={'browser': 'Chrome'},
+        command_executor="http://127.0.0.1:4444/wd/hub",
+        desired_capabilities={"browser": "Chrome"},
         file_detector=None,
         keep_alive=False,
         options=None,
         proxy=None,
     )
-    wrapper.stop()
+    wrapper._stop()
     # For some reason, calling the Mock provides a reference to the instance
     # that was created when the mock was previously instantiated
     MockRemote().close.assert_called()
@@ -86,7 +86,7 @@ async def test_selenium_context_manager():
         pass
 
     # patch with async decorator misbehaving
-    with patch('mite_selenium.Remote', autospec=True) as MockRemote:
+    with patch("mite_selenium.Remote", autospec=True) as MockRemote:
         await test(context)
 
     MockRemote.assert_called()


### PR DESCRIPTION
-Added metrics for mite selenium tests, including both page load metrics and network resource metrics for downstream resources.

- Fixed a bug regarding the Histogram whereby the bin_counts was being used to iterate on and append the metrics. if all of the metric value fell in the infinite bin, this would mean there was nothing to iterate through and therefore would not append the metrics.

- Some mad formatting.
