### PR TITLE
Provide access to the Selenium webdriver instance on _SeleniumWrapper

### DIFF
--- a/mite_selenium/__init__.py
+++ b/mite_selenium/__init__.py
@@ -50,6 +50,7 @@ class _SeleniumWrapper:
             file_detector=self._file_detector,
             options=self._options,
         )
+        self._context.webdriver = self._remote
 
     def _stop(self):
         self._remote.close()

--- a/mite_selenium/__init__.py
+++ b/mite_selenium/__init__.py
@@ -50,7 +50,7 @@ class _SeleniumWrapper:
             file_detector=self._file_detector,
             options=self._options,
         )
-        self._context.webdriver = self._remote
+        self._context.raw_webdriver = self._remote
 
     def _stop(self):
         self._remote.close()


### PR DESCRIPTION
These changes give access to the Selenium webdriver via context. Normally classes wrapped by _SeleniumWrapper proxy calls to webdriver methods through that class's methods - for instance to collect statistics. However, there are cases where proxied access isn't required or desirable.