### PR TITLE
Test session cookies sent on subsequent requests

### DIFF
--- a/acurl/tests/test_httpbin.py
+++ b/acurl/tests/test_httpbin.py
@@ -40,6 +40,19 @@ async def test_session_cookies(httpbin):
 
 
 @pytest.mark.asyncio
+async def test_session_cookies_sent_on_subsequent_request(httpbin):
+    s = session()
+    await s.get(httpbin.url + "/cookies/set?name=value")
+    cookie_list = s.get_cookie_list()
+    assert len(cookie_list) == 1
+    assert cookie_list[0].name == "name"
+    resp = await s.get(httpbin.url + "/cookies")
+    data = resp.json()
+    assert len(data) == 1
+    assert data["cookies"] == {"name": "value"}
+
+
+@pytest.mark.asyncio
 async def test_set_cookies(httpbin):
     s = session()
     await s.get(httpbin.url + "/cookies/set?name=value")

--- a/acurl/tests/test_httpbin.py
+++ b/acurl/tests/test_httpbin.py
@@ -43,9 +43,6 @@ async def test_session_cookies(httpbin):
 async def test_session_cookies_sent_on_subsequent_request(httpbin):
     s = session()
     await s.get(httpbin.url + "/cookies/set?name=value")
-    cookie_list = s.get_cookie_list()
-    assert len(cookie_list) == 1
-    assert cookie_list[0].name == "name"
     resp = await s.get(httpbin.url + "/cookies")
     data = resp.json()
     assert len(data) == 1


### PR DESCRIPTION
- Added tests to cover scenario whereby cookies should be sent to domain on subsequent requests after being dropped on the initial request.