### PR TITLE
Fix to add missing perform_request() function prototype.

### DIFF
--- a/acurl/src/acurl.h
+++ b/acurl/src/acurl.h
@@ -147,6 +147,7 @@ extern PyTypeObject EventLoopType;
 extern PyTypeObject ResponseType;
 extern PyTypeObject SessionType;
 void start_request(struct aeEventLoop *eventLoop, int fd, void *clientData, int mask);
+void perform_request(AcRequestData *rd);
 void free_buffer_nodes(BufferNode *start);
 void schedule_cleanup_curl_share(Session *session, CURLSH *share);
 void schedule_cleanup_curl_easy(Session *session, CURL *ptr);


### PR DESCRIPTION
`acurl.h` was missing the `perform_request()` function prototype, causing a gcc build error in some (but not all) versions of gcc when running `pip install acurl`. This PR adds the prototype to `acurl.h` to fix that issue.