### PR TITLE
Adding cookie wrapper to allow for overriding cookie domain

### DIFF
--- a/acurl/acurl/__init__.py
+++ b/acurl/acurl/__init__.py
@@ -25,6 +25,18 @@ _FALSE_TRUE = ["FALSE", "TRUE"]
 
 
 class Cookie:
+    def __init__(
+        self,
+        domain,
+        name,
+        value,
+    ):
+        self.domain = domain
+        self.name = name
+        self.value = value
+
+
+class _Cookie:
     __slots__ = "_http_only _domain _include_subdomains _path _is_secure _expiration _name _value".split()
 
     def __init__(
@@ -134,7 +146,7 @@ def parse_cookie_string(cookie_string):
         value = ""
     else:
         domain, include_subdomains, path, is_secure, expiration, name, value = parts
-    return Cookie(
+    return _Cookie(
         http_only,
         domain,
         include_subdomains == "TRUE",
@@ -166,16 +178,18 @@ def session_cookie_for_url(
     scheme, netloc, path, params, query, fragment = urlparse(url)
     if not include_url_path:
         path = "/"
+
+    is_type_cookie = isinstance(value, Cookie)
     # TODO do we need to sanitize netloc for IP and ports?
-    return Cookie(
+    return _Cookie(
         http_only,
-        "." + netloc.split(":")[0],
+        value.domain if is_type_cookie else "." + netloc.split(":")[0],
         include_subdomains,
         path,
         is_secure,
         0,
-        name,
-        value,
+        value.name if is_type_cookie else name,
+        value.value if is_type_cookie else value,
     )
 
 

--- a/acurl/tests/test_cookie.py
+++ b/acurl/tests/test_cookie.py
@@ -1,29 +1,32 @@
-import acurl
-import pytest
 import time
+
+import pytest
+
+import acurl
+from acurl import Cookie
 
 
 @pytest.mark.skip
 def test_cookie_zero_expiry():
     # FIXME: what's the right behavior here?ssss
-    c = acurl.Cookie(False, "foo.com", False, "/bar", False, 0, "my_cookie", "my_value")
+    c = acurl._Cookie(False, "foo.com", False, "/bar", False, 0, "my_cookie", "my_value")
     assert not c.has_expired
 
 
 def test_cookie_not_expired():
-    c = acurl.Cookie(
+    c = acurl._Cookie(
         False, "foo.com", False, "/bar", False, time.time() + 200, "my_cookie", "my_value"
     )
     assert not c.has_expired
 
 
 def test_cookie_has_expired():
-    c = acurl.Cookie(False, "foo.com", False, "/bar", False, 1, "my_cookie", "my_value")
+    c = acurl._Cookie(False, "foo.com", False, "/bar", False, 1, "my_cookie", "my_value")
     assert c.has_expired
 
 
 def test_cookie_format():
-    c = acurl.Cookie(False, "foo.com", False, "/bar", False, 0, "my_cookie", "my_value")
+    c = acurl._Cookie(False, "foo.com", False, "/bar", False, 0, "my_cookie", "my_value")
     assert c.format() == "foo.com\tFALSE\t/bar\tFALSE\t0\tmy_cookie\tmy_value"
 
 
@@ -63,3 +66,18 @@ def test_parse_cookie_string_http_only():
     assert c.expiration == 0
     assert c.name == "my_cookie"
     assert c.value == "my_value"
+
+
+def test_session_cookie_for_url_with_cookie_instance():
+    c = Cookie("sky.com", "foo", "bar")
+    cookie = acurl.session_cookie_for_url(url="https://kys.com", name="baz", value=c)
+    assert cookie.domain == "sky.com"
+    assert cookie.name == "foo"
+    assert cookie.value == "bar"
+
+
+def test_session_cookie_for_url_with_cookie_value():
+    cookie = acurl.session_cookie_for_url(url="https://sky.com", name="foo", value="bar")
+    assert cookie.domain == ".sky.com"
+    assert cookie.name == "foo"
+    assert cookie.value == "bar"

--- a/acurl/tests/test_cookie.py
+++ b/acurl/tests/test_cookie.py
@@ -76,7 +76,7 @@ def test_session_cookie_for_url_with_cookie_instance():
     assert cookie.value == "bar"
 
 
-def test_session_cookie_for_url_with_cookie_value():
+def test_session_cookie_for_url_with_string_value():
     cookie = acurl.session_cookie_for_url(url="https://sky.com", name="foo", value="bar")
     assert cookie.domain == ".sky.com"
     assert cookie.name == "foo"

--- a/acurl/tests/test_to_curl.py
+++ b/acurl/tests/test_to_curl.py
@@ -23,7 +23,7 @@ def test_to_curl_cookies():
     r = create_request(
         "GET",
         "http://foo.com",
-        cookies=(acurl.Cookie(False, "foo.com", True, "/", False, 0, "123", "456"),),
+        cookies=(acurl._Cookie(False, "foo.com", True, "/", False, 0, "123", "456"),),
     )
     assert r.to_curl() == "curl -X GET  --cookie 123=456   http://foo.com"
 
@@ -33,8 +33,8 @@ def test_to_curl_multiple_cookies():
         "GET",
         "http://foo.com",
         cookies=(
-            acurl.Cookie(False, "foo.com", True, "/", False, 0, "123", "456"),
-            acurl.Cookie(False, "foo.com", True, "/", False, 0, "789", "abc"),
+            acurl._Cookie(False, "foo.com", True, "/", False, 0, "123", "456"),
+            acurl._Cookie(False, "foo.com", True, "/", False, 0, "789", "abc"),
         ),
     )
     assert r.to_curl() == "curl -X GET  --cookie '123=456;789=abc'   http://foo.com"
@@ -50,7 +50,7 @@ def test_to_curl_cookies_wrong_domain():
         "GET",
         "http://foo.com",
         cookies=(
-            acurl.Cookie(
+            acurl._Cookie(
                 False,
                 "bar.com",  # The domain doesn't match, the cookie should not be passed
                 True,


### PR DESCRIPTION
Adding a cookie wrapper to allow for the overriding of the cookie domain, name and value when required.