### PR TITLE
Fix an error weʼve seen after #182

### DIFF
--- a/mite/datapools.py
+++ b/mite/datapools.py
@@ -15,6 +15,7 @@ class RecyclableIterableDataPool:
     def __init__(self, iterable):
         self._data = iterable
         self._initialized = False
+        self._available = None
 
     def _initialize_once(self):
         if self._initialized:
@@ -32,6 +33,12 @@ class RecyclableIterableDataPool:
             raise Exception("Recyclable iterable datapool was emptied!")
 
     async def checkin(self, id):
+        if self._available is None:
+            logger.error(
+                f"{repr(self)}: checkin called for {id} before the datapool "
+                "was initialized!  Maybe a stale runner is hanging around"
+            )
+            return
         self._available.append(id)
 
 


### PR DESCRIPTION
In my testing, I couldnʼt reproduce the error reliably.  But if a stale
runner from a previous test run was hanging around, then it would
trigger the behavior we saw.  I canʼt figure out why we would have had
such a stale runner in our overnight test – it should have been a clean
environment – but in any case, this change converts an exception into an
error log, to prevent us from crashing in this case