### PR TITLE
Fixes for reaching higher 7.5 million TPS during testing

### DIFF
--- a/mite/datapools.py
+++ b/mite/datapools.py
@@ -1,5 +1,6 @@
 import logging
 from collections import deque, namedtuple
+from itertools import cycle
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +64,7 @@ def iterable_datapool(fn):
 
 
 def recyclable_iterable_datapool(fn):
-    return RecyclableIterableDataPool(fn())
+    return IterableDataPool(cycle(fn()))
 
 
 class SingleRunDataPool:

--- a/mite/zmq.py
+++ b/mite/zmq.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class Duplicator:
     def __init__(self, in_address, out_addresses, loop=None):
-        self._zmq_context = zmq.Context(io_threads=4)
+        self._zmq_context = zmq.Context()
         self._in_socket = self._zmq_context.socket(zmq.PULL)
         self._in_socket.bind(in_address)
         self._out_sockets = [

--- a/mite/zmq.py
+++ b/mite/zmq.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class Duplicator:
     def __init__(self, in_address, out_addresses, loop=None):
-        self._zmq_context = zmq.Context()
+        self._zmq_context = zmq.Context(io_threads=4)
         self._in_socket = self._zmq_context.socket(zmq.PULL)
         self._in_socket.bind(in_address)
         self._out_sockets = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ console_scripts =
 mite_stats =
     mite = mite.stats:_MITE_STATS
     mite_http = mite_http.stats:STATS
-    mite_selenium = mite_selenium.stats:STATS
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Fix for Recyclable iterable datapool getting exhausted on higher 7.5 million TPS

Remove selenium from mite stats in an effort to lower the nr of stats replicas needed to reach 7.5 million TPS