### PR TITLE
Log out if the all scenarios have been removed from the scenario tracker

### DIFF
--- a/mite/scenario.py
+++ b/mite/scenario.py
@@ -64,6 +64,8 @@ class ScenarioManager:
                     scenario_id,
                 )
                 del self._scenarios[scenario_id]
+                if len(self._scenarios) == 0:
+                    logger.info("All scenarios have been removed from scenario tracker")
             else:
                 required[scenario_id] = number
         self._current_period_end = end_of_period


### PR DESCRIPTION
Add a small check on the scenario list size at line 68 and log out if the all scenarios have been removed from the scenario tracker.