### PR TITLE
Add selenium-wire support

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,4 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 known_first_party=_acurl
-known_third_party = aio_pika,altair,bs4,docopt,flask,helpers,jinja2,mocks,msgpack,nanomsg,pandas,pkg_resources,psutil,pytest,pytest_httpserver,sanic,selenium,seleniumwire,setuptools,ujson,uvloop,websockets,werkzeug,zmq
+known_third_party = aio_pika,altair,bs4,docopt,flask,helpers,jinja2,mocks,msgpack,nanomsg,pandas,pkg_resources,psutil,pytest,pytest_httpserver,sanic,selenium,setuptools,ujson,uvloop,websockets,werkzeug,zmq

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -5,4 +5,4 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 known_first_party=_acurl
-known_third_party = aio_pika,altair,bs4,docopt,flask,helpers,jinja2,mocks,msgpack,nanomsg,pandas,pkg_resources,psutil,pytest,pytest_httpserver,sanic,selenium,setuptools,ujson,uvloop,websockets,werkzeug,zmq
+known_third_party = aio_pika,altair,bs4,docopt,flask,helpers,jinja2,mocks,msgpack,nanomsg,pandas,pkg_resources,psutil,pytest,pytest_httpserver,sanic,selenium,seleniumwire,setuptools,ujson,uvloop,websockets,werkzeug,zmq

--- a/mite_selenium/__init__.py
+++ b/mite_selenium/__init__.py
@@ -28,10 +28,10 @@ class _SeleniumWrapper:
             "webdriver_command_executor", "http://127.0.0.1:4444/wd/hub"
         )
         self._keep_alive = self._context.config.get("webdriver_keep_alive", False)
-        self._file_detector = self._spec_import_if_none("webdriver_file_detector")
-        self._proxy = self._spec_import_if_none("webdriver_proxy")
-        self._browser_profile = self._spec_import_if_none("webdriver_browser_profile")
-        self._options = self._spec_import_if_none("webdriver_options")
+        self._file_detector = self._spec_import_if_not_none("webdriver_file_detector")
+        self._proxy = self._spec_import_if_not_none("webdriver_proxy")
+        self._browser_profile = self._spec_import_if_not_none("webdriver_browser_profile")
+        self._options = self._spec_import_if_not_none("webdriver_options")
 
         # Required param
         self._capabilities = self._context.config.get("webdriver_capabilities")

--- a/mite_selenium/__init__.py
+++ b/mite_selenium/__init__.py
@@ -37,7 +37,7 @@ class _SeleniumWrapper:
         self._capabilities = self._context.config.get("webdriver_capabilities")
         self._capabilities = spec_import(self._capabilities)
 
-    def _spec_import_if_none(self, config_option):
+    def _spec_import_if_not_none(self, config_option):
         value = self._context.config.get(config_option, None)
         if value:
             value = spec_import(value)
@@ -211,15 +211,17 @@ class JsMetricsContext:
 
 
 class _SeleniumWireWrapper(_SeleniumWrapper):
-    def __init__(self, context, selenium_wire_remote):
+    def __init__(self, context):
         super().__init__(context)
-        self._selenium_wire_remote = selenium_wire_remote
-        self._seleniumwire_options = self._spec_import_if_none("seleniumwire_options")
+        self._seleniumwire_options = (
+            self._spec_import_if_not_none("seleniumwire_options") or {}
+        )
 
     def _start(self):
+        module = importlib.import_module("seleniumwire.webdriver")
         self._context.browser = self
         addr = socket.gethostbyname(socket.gethostname())
-        self._remote = self._selenium_wire_remote(
+        self._remote = module.Remote(
             desired_capabilities=self._capabilities,
             command_executor=self._command_executor,
             browser_profile=self._browser_profile,
@@ -240,30 +242,42 @@ class _SeleniumWireWrapper(_SeleniumWrapper):
 
 
 @asynccontextmanager
-async def _selenium_context_manager(context, selenium_wire_remote=None):
+async def _selenium_context_manager(context, wire):
+    if wire:
+        sw = _SeleniumWireWrapper(context)
+    else:
+        sw = _SeleniumWrapper(context)
+
     try:
-        if selenium_wire_remote:
-            sw = _SeleniumWireWrapper(context, selenium_wire_remote)
-        else:
-            sw = _SeleniumWrapper(context)
         sw._start()
         yield
     finally:
         sw._quit()
 
 
-def mite_selenium(wire=False):
+def mite_selenium(*args, wire=False):
     def wrapper_factory(func):
-        selenium_wire_remote = None
         if wire:
-            module = importlib.import_module("seleniumwire.webdriver")
-            selenium_wire_remote = getattr(module, "Remote")
+            try:
+                importlib.import_module("seleniumwire.webdriver")
+            except ModuleNotFoundError:
+                raise Exception(
+                    "The wire=True argument to mite_selenium is only supported "
+                    + "if mite was installed with the 'selenium_wire' extra"
+                )
 
         @wraps(func)
         async def wrapper(ctx, *args, **kwargs):
-            async with _selenium_context_manager(ctx, selenium_wire_remote):
+            async with _selenium_context_manager(ctx, wire):
                 return await func(ctx, *args, **kwargs)
 
         return wrapper
 
-    return wrapper_factory
+    if len(args) == 0:
+        # invoked as @mite_selenium(wire=...) def foo(...)
+        return wrapper_factory
+    elif len(args) > 1:
+        raise Exception("Anomalous invocation of mite_welenium decorator")
+    else:
+        # len(args) == 1; invoked as @mite_selenium def foo(...)
+        return wrapper_factory(args[0])

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ tests_require = pytest
 packages = find:
 
 [options.extras_require]
-SELENIUMWIRE = selenium-wire>=4.3.0
+selenium_wire = selenium-wire>=4.3.0
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ install_requires =
     nanomsg
     pyzmq
     selenium
+    selenium-wire
     uvloop
     websockets
 setup_requires = pytest-runner

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,12 +12,14 @@ install_requires =
     nanomsg
     pyzmq
     selenium
-    selenium-wire
     uvloop
     websockets
 setup_requires = pytest-runner
 tests_require = pytest
 packages = find:
+
+[options.extras_require]
+SELENIUMWIRE = selenium-wire>=4.3.0
 
 [options.entry_points]
 console_scripts =

--- a/test/test_webdriver.py
+++ b/test/test_webdriver.py
@@ -205,7 +205,7 @@ async def test_selenium_context_manager():
     context = MockContext()
     context.config = DICT_CAPABILITIES_CONFIG
 
-    @mite_selenium
+    @mite_selenium()
     async def test(context):
         pass
 

--- a/test/test_webdriver.py
+++ b/test/test_webdriver.py
@@ -205,6 +205,23 @@ async def test_selenium_context_manager():
     context = MockContext()
     context.config = DICT_CAPABILITIES_CONFIG
 
+    @mite_selenium
+    async def test(context):
+        pass
+
+    # patch with async decorator misbehaving
+    with patch("mite_selenium.Remote", autospec=True) as mock_remote:
+        await test(context)
+
+    mock_remote.assert_called()
+    mock_remote().close.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_selenium_context_manager_with_parens():
+    context = MockContext()
+    context.config = DICT_CAPABILITIES_CONFIG
+
     @mite_selenium()
     async def test(context):
         pass

--- a/test/test_webdriver.py
+++ b/test/test_webdriver.py
@@ -60,7 +60,7 @@ def test_webdriver_capabilities_as_dict():
     assert wrapper._capabilities == {"browser": "Chrome"}
 
 
-@patch("mite_selenium.Remote", autospec=True)
+@patch("mite_selenium.SeleniumRemote", autospec=True)
 def test_webdriver_start_stop(MockRemote):
     wrapper = _setup_wrapper(DICT_CAPABILITIES_CONFIG)
     wrapper._start()
@@ -73,10 +73,10 @@ def test_webdriver_start_stop(MockRemote):
         options=None,
         proxy=None,
     )
-    wrapper._stop()
+    wrapper._quit()
     # For some reason, calling the Mock provides a reference to the instance
     # that was created when the mock was previously instantiated
-    MockRemote().close.assert_called()
+    MockRemote().quit.assert_called()
 
 
 def test_get_js_metrics_context():
@@ -89,7 +89,7 @@ def test_get_js_metrics_context():
 @pytest.mark.asyncio
 async def test_js_metrics_context_manager():
     wrapper = _setup_wrapper(DICT_CAPABILITIES_CONFIG)
-    with patch("mite_selenium.Remote") as mock_remote:
+    with patch("mite_selenium.SeleniumRemote") as mock_remote:
         wrapper._start()
         js_context = wrapper.get_js_metrics_context()
 
@@ -105,7 +105,7 @@ async def test_js_metrics_context_manager():
 
 def test_wait_for_element():
     wrapper = _setup_wrapper(DICT_CAPABILITIES_CONFIG)
-    with patch("mite_selenium.Remote") as mock_remote, patch(
+    with patch("mite_selenium.SeleniumRemote") as mock_remote, patch(
         "mite_selenium.WebDriverWait"
     ) as mock_web_driver_wait, patch("mite_selenium.EC") as mock_ec:
         wrapper._start()
@@ -121,7 +121,7 @@ def test_wait_for_element():
 
 def test_wait_for_element_raises_timeout_exception():
     wrapper = _setup_wrapper(DICT_CAPABILITIES_CONFIG)
-    with patch("mite_selenium.Remote"), patch(
+    with patch("mite_selenium.SeleniumRemote"), patch(
         "mite_selenium.WebDriverWait"
     ) as mock_web_driver_wait, patch("mite_selenium.EC"):
         wrapper._start()
@@ -133,7 +133,7 @@ def test_wait_for_element_raises_timeout_exception():
 
 def test_wait_for_elements():
     wrapper = _setup_wrapper(DICT_CAPABILITIES_CONFIG)
-    with patch("mite_selenium.Remote") as mock_remote, patch(
+    with patch("mite_selenium.SeleniumRemote") as mock_remote, patch(
         "mite_selenium.WebDriverWait"
     ) as mock_web_driver_wait, patch("mite_selenium.EC") as mock_ec:
         wrapper._start()
@@ -149,7 +149,7 @@ def test_wait_for_elements():
 
 def test_wait_for_elements_raises_timeout_exception():
     wrapper = _setup_wrapper(DICT_CAPABILITIES_CONFIG)
-    with patch("mite_selenium.Remote"), patch(
+    with patch("mite_selenium.SeleniumRemote"), patch(
         "mite_selenium.WebDriverWait"
     ) as mock_web_driver_wait, patch("mite_selenium.EC"):
         wrapper._start()
@@ -161,7 +161,7 @@ def test_wait_for_elements_raises_timeout_exception():
 
 def test_wait_for_url():
     wrapper = _setup_wrapper(DICT_CAPABILITIES_CONFIG)
-    with patch("mite_selenium.Remote") as mock_remote, patch(
+    with patch("mite_selenium.SeleniumRemote") as mock_remote, patch(
         "mite_selenium.WebDriverWait"
     ) as mock_web_driver_wait, patch("mite_selenium.EC") as mock_ec:
         wrapper._start()
@@ -177,7 +177,7 @@ def test_wait_for_url():
 
 def test_wait_for_url_raises_timeout_exception():
     wrapper = _setup_wrapper(DICT_CAPABILITIES_CONFIG)
-    with patch("mite_selenium.Remote"), patch(
+    with patch("mite_selenium.SeleniumRemote"), patch(
         "mite_selenium.WebDriverWait"
     ) as mock_web_driver_wait, patch("mite_selenium.EC"):
         wrapper._start()
@@ -189,7 +189,7 @@ def test_wait_for_url_raises_timeout_exception():
 
 def test_webdriver_get():
     wrapper = _setup_wrapper(DICT_CAPABILITIES_CONFIG)
-    with patch("mite_selenium.Remote") as mock_remote:
+    with patch("mite_selenium.SeleniumRemote") as mock_remote:
         mock_remote.return_value.capabilities = {"browserName": "chrome"}
         wrapper._start()
         wrapper.get("https://google.com")
@@ -210,11 +210,11 @@ async def test_selenium_context_manager():
         pass
 
     # patch with async decorator misbehaving
-    with patch("mite_selenium.Remote", autospec=True) as mock_remote:
+    with patch("mite_selenium.SeleniumRemote", autospec=True) as mock_remote:
         await test(context)
 
     mock_remote.assert_called()
-    mock_remote().close.assert_called()
+    mock_remote().quit.assert_called()
 
 
 @pytest.mark.asyncio
@@ -227,11 +227,11 @@ async def test_selenium_context_manager_with_parens():
         pass
 
     # patch with async decorator misbehaving
-    with patch("mite_selenium.Remote", autospec=True) as mock_remote:
+    with patch("mite_selenium.SeleniumRemote", autospec=True) as mock_remote:
         await test(context)
 
     mock_remote.assert_called()
-    mock_remote().close.assert_called()
+    mock_remote().quit.assert_called()
 
 
 def _setup_wrapper(capabilites):


### PR DESCRIPTION
Use selenium remote driver quit instead of stop to avoid exhausting the selenium browser sessions/instances while waiting for browser timeouts