### PR TITLE
Review comments

### DIFF
--- a/mite_selenium/__init__.py
+++ b/mite_selenium/__init__.py
@@ -213,12 +213,15 @@ class JsMetricsContext:
 class _SeleniumWireWrapper(_SeleniumWrapper):
     def __init__(self, context):
         super().__init__(context)
-        self._seleniumwire_options = self._spec_import_if_not_none("seleniumwire_options")
+        self._seleniumwire_options = (
+            self._spec_import_if_not_none("seleniumwire_options") or {}
+        )
 
     def _start(self):
+        module = importlib.import_module("seleniumwire.webdriver")
         self._context.browser = self
         addr = socket.gethostbyname(socket.gethostname())
-        self._remote = self._selenium_wire_remote(
+        self._remote = module.Remote(
             desired_capabilities=self._capabilities,
             command_executor=self._command_executor,
             browser_profile=self._browser_profile,
@@ -260,7 +263,7 @@ def mite_selenium(*args, wire=False):
             except ModuleNotFoundError:
                 raise Exception(
                     "The wire=True argument to mite_selenium is only supported "
-                    + "if mite was installed with the selenium_wire extra"
+                    + "if mite was installed with the 'selenium_wire' extra"
                 )
 
         @wraps(func)

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ tests_require = pytest
 packages = find:
 
 [options.extras_require]
-SELENIUMWIRE = selenium-wire>=4.3.0
+selenium_wire = selenium-wire>=4.3.0
 
 [options.entry_points]
 console_scripts =

--- a/test/test_webdriver.py
+++ b/test/test_webdriver.py
@@ -205,6 +205,23 @@ async def test_selenium_context_manager():
     context = MockContext()
     context.config = DICT_CAPABILITIES_CONFIG
 
+    @mite_selenium
+    async def test(context):
+        pass
+
+    # patch with async decorator misbehaving
+    with patch("mite_selenium.Remote", autospec=True) as mock_remote:
+        await test(context)
+
+    mock_remote.assert_called()
+    mock_remote().close.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_selenium_context_manager_with_parens():
+    context = MockContext()
+    context.config = DICT_CAPABILITIES_CONFIG
+
     @mite_selenium()
     async def test(context):
         pass


### PR DESCRIPTION
- fix name of `_spec_import_if_not_none`
- make the name of the setuptools extra lower_snake_case (which seems to be the most common casing in the wild...)
- change how the `wire` argument is passed through the call chain
- raise an early, descriptive error is selenium-wire is needed but not found
- fix a bug in the case where seleniumwire_options is not given
- make it possible to invoke `mite_selenium` with or without parens
  - add unit test coverage for both cases