### PR TITLE
Acurl cleanups and memleak fixes

### DIFF
--- a/Dockerfile.perftest
+++ b/Dockerfile.perftest
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.9
 
 COPY ./test/perf/test-requirements.txt /test-requirements.txt
 

--- a/acurl/.gitignore
+++ b/acurl/.gitignore
@@ -20,3 +20,5 @@ __pycache__/
 # C
 *.so
 cython_debug/
+src/*.c
+src/*.html

--- a/acurl/src/cookie.pyx
+++ b/acurl/src/cookie.pyx
@@ -1,6 +1,6 @@
 #cython: language_level=3
 
-import time
+from libc.time cimport time
 from urllib.parse import urlparse
 
 
@@ -46,7 +46,7 @@ cdef class _Cookie:
 
     @property
     def has_expired(self):
-        return self.expiration != 0 and time.time() > self.expiration
+        return self.expiration != 0 and time(NULL) > self.expiration
 
     cdef bytes format(self):
         cdef array.array bits = array.array('B', [])

--- a/acurl/src/cookie.pyx
+++ b/acurl/src/cookie.pyx
@@ -24,7 +24,17 @@ cdef class _Cookie:
     cdef str name
     cdef str value
 
-    def __cinit__(self, bint http_only, str domain, bint include_subdomains, str path, bint is_secure, int expiration, str name, str value):
+    def __cinit__(
+        self,
+        bint http_only,
+        str domain,
+        bint include_subdomains,
+        str path,
+        bint is_secure,
+        int expiration,
+        str name,
+        str value
+    ):
         self.http_only = http_only
         self.domain = domain
         self.include_subdomains = include_subdomains

--- a/acurl/src/cookie.pyx
+++ b/acurl/src/cookie.pyx
@@ -5,9 +5,9 @@ from urllib.parse import urlparse
 
 
 cdef class Cookie:
-    cdef str domain
-    cdef str name
-    cdef str value
+    cdef readonly str domain
+    cdef readonly str name
+    cdef readonly str value
 
     def __cinit__(self, domain, name, value):
         self.domain = domain
@@ -15,14 +15,14 @@ cdef class Cookie:
         self.value = value
 
 cdef class _Cookie:
-    cdef bint http_only
-    cdef str domain
-    cdef bint include_subdomains
-    cdef str path
-    cdef bint is_secure
-    cdef int expiration  # TODO right type???
-    cdef str name
-    cdef str value
+    cdef readonly bint http_only
+    cdef readonly str domain
+    cdef readonly bint include_subdomains
+    cdef readonly str path
+    cdef readonly bint is_secure
+    cdef readonly int expiration  # TODO right type???
+    cdef readonly str name
+    cdef readonly str value
 
     def __cinit__(
         self,
@@ -48,7 +48,7 @@ cdef class _Cookie:
     def has_expired(self):
         return self.expiration != 0 and time(NULL) > self.expiration
 
-    cdef bytes format(self):
+    cpdef bytes format(self):
         cdef array.array bits = array.array('B', [])
         if self.http_only:
             bits.frombytes(b"#HttpOnly_")

--- a/acurl/src/request.pyx
+++ b/acurl/src/request.pyx
@@ -35,12 +35,10 @@ cdef class Request:
     cdef void store_session_cookies(self, CURLSH* shared):
         cdef CURL* curl = curl_easy_init()
         acurl_easy_setopt_voidptr(curl, CURLOPT_SHARE, shared)
-        # NOTE: Do dummy request in order to extract the cookies list
-
         raw_cookies = tuple(parse_cookie_string(c) for c in acurl_extract_cookielist(curl))
         session_cookies = tuple(
             c.format()
-            for c in raw_cookies 
+            for c in raw_cookies
             if urlparse(self.url).hostname.lower() == c.domain.lower()
         )
         self.session_cookies = session_cookies

--- a/acurl/src/request.pyx
+++ b/acurl/src/request.pyx
@@ -42,6 +42,7 @@ cdef class Request:
         cdef CURL* curl = curl_easy_init()
         acurl_easy_setopt_voidptr(curl, CURLOPT_SHARE, shared)
         raw_cookies = tuple(parse_cookie_string(c) for c in acurl_extract_cookielist(curl))
+        curl_easy_cleanup(curl)
         session_cookies = tuple(
             c.format()
             for c in raw_cookies

--- a/acurl/src/request.pyx
+++ b/acurl/src/request.pyx
@@ -12,6 +12,7 @@ cdef class Request:
     cdef readonly object data
     cdef readonly object cert
     cdef tuple session_cookies
+    cdef curl_slist* curl_headers
 
     def __cinit__(
         self,
@@ -31,6 +32,11 @@ cdef class Request:
         self.data = data
         self.cert = cert
         self.session_cookies = ()  # Tuple of byte strings
+        self.curl_headers = NULL
+
+    def __dealloc__(self):
+        if self.curl_headers != NULL:
+            curl_slist_free_all(self.curl_headers)
 
     cdef void store_session_cookies(self, CURLSH* shared):
         cdef CURL* curl = curl_easy_init()

--- a/acurl/src/response.pyx
+++ b/acurl/src/response.pyx
@@ -48,19 +48,32 @@ cdef class _Response:
         self._prev = None
 
     def __dealloc__(self):
+        # Subtle behavior alert!  We cleanup the curl handle before we free
+        # header_buffer and body_buffer.  As the curl docs say:
+        # > Occasionally you may get your progress callback or header callback
+        # > called from within curl_easy_cleanup.
+        # If that happens, then the handler would attach more nodes to the
+        # header/body buffers, which we'll need to free.  That is perhaps
+        # unlikely, given that the docs say further:
+        # > [This happens if] the protocol is of a kind that requires a
+        # > command/response sequence before disconnect.  Examples of such
+        # > protocols are FTP, POP3 and IMAP.
+        # But better safe than sorry.
+        curl_easy_cleanup(self.curl)
         cdef BufferNode* ptr
         cdef BufferNode* old_ptr
         ptr = self.header_buffer
         while ptr != NULL:
             old_ptr = ptr
+            free(ptr.buffer)
             ptr = ptr.next
             free(old_ptr)
         ptr = self.body_buffer
         while ptr != NULL:
             old_ptr = ptr
+            free(ptr.buffer)
             ptr = ptr.next
             free(old_ptr)
-        # FIXME: Dealloc curl
 
     # In principle it would be better to do this through a normal init
     # method.  Howver, there is a restriction on what arguments can be passed

--- a/acurl/src/response.pyx
+++ b/acurl/src/response.pyx
@@ -111,7 +111,11 @@ cdef class _Response:
 
     @property
     def response_code(self):
-        warnings.warn("Deprecated: Please consider using the status_code method instead", DeprecationWarning, stacklevel=2)
+        warnings.warn(
+            "Deprecated: Please consider using the status_code method instead",
+            DeprecationWarning,
+            stacklevel=2
+        )
         return self.get_info_long(CURLINFO_RESPONSE_CODE)
 
     @property

--- a/acurl/src/session.pyx
+++ b/acurl/src/session.pyx
@@ -1,13 +1,12 @@
 #cython: language_level=3
 
-import time  # FIXME: use fast c fn
-
 from libc.stdlib cimport malloc
 from libc.string cimport strndup
 from cpython.pycapsule cimport PyCapsule_New, PyCapsule_GetPointer
 from curlinterface cimport *
 from cpython.ref cimport Py_INCREF
 from libc.stdio cimport printf
+from libc.time cimport time
 import cython
 from json import dumps
 
@@ -140,7 +139,7 @@ cdef class Session:
 
         cdef Request request = Request.__new__(Request, method, url, headers, cookies, auth, data, cert)
         request.store_session_cookies(self.shared)
-        cdef _Response response = _Response.make(self, curl, future, time.time(), request)  # FIXME: use a c time fn
+        cdef _Response response = _Response.make(self, curl, future, time(NULL), request)
 
         # We need to increment the reference count on the response.  To
         # python's eyes the last reference to it disappears when we exit this

--- a/acurl/src/session.pyx
+++ b/acurl/src/session.pyx
@@ -93,10 +93,12 @@ cdef class Session:
         self.response_callback = None
 
     def __dealloc__(self):
-        if self.wrapper.loop.is_closed():
+        if self.wrapper.loop is None or self.wrapper.loop.is_closed():
             # FIXME: the event loop being closed only happens during testing,
             # so it kind of sucks to pay the price of checking for it all the
-            # time...
+            # time.  I'm not even sure what the circumstances are under which
+            # self.wrapper.loop becomes None -- I suspect it has to do with
+            # the cycle collector.
             curl_share_cleanup(self.shared)
         else:
             self.wrapper.loop.call_soon(cleanup_share, PyCapsule_New(self.shared, NULL, NULL))

--- a/acurl/src/session.pyx
+++ b/acurl/src/session.pyx
@@ -256,6 +256,12 @@ cdef class Session:
             data,
             cert,
         )
+        # This decref is the partner to the incref in _inner_request above --
+        # at this point curl is done with the response and so we no longer
+        # need to keep its refcount incremented to prevent the GC from
+        # cleaning it up when the only reference to it is held by curl and not
+        # python.
+        Py_DECREF(response)
         cdef _Response old_response
         if self.response_callback:
             # FIXME: should this be async?

--- a/acurl/src/session.pyx
+++ b/acurl/src/session.pyx
@@ -21,7 +21,15 @@ cdef BufferNode* alloc_buffer_node(size_t size, char *data):
     if node == NULL:
         printf("OOOPS!!!!")  # FIXME: better checks
     node.len = size
-    node.buffer = strndup(data, size)
+    # FIXME: the curl docs give an example function that uses realloc on a
+    # single buffer rather than a linked list.  Possibly that method would be
+    # faster (as well as less complicated) -- especially if we preallocate a
+    # buffer for headers/data when allocating a response (paying a small
+    # memory cost in exchange for not having to allocate while processing
+    # response data).  It would also make the code less complicated.  Worth
+    # benchmarking the effects someday...
+    # <https://curl.se/libcurl/c/CURLOPT_WRITEFUNCTION.html>
+    node.buffer = strndup(data, size)  # FIXME: use realloc?
     node.next = NULL
     return node
 

--- a/acurl/src/utils.pyx
+++ b/acurl/src/utils.pyx
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 
 class _CaseInsensitiveDict:
-    # Base on https://stackoverflow.com/a/32888599 but tweaked for python3
+    # Based on https://stackoverflow.com/a/32888599 but tweaked for python3
     @staticmethod
     def _k(key):
         return key.lower() if isinstance(key, str) else key

--- a/acurl/valgrind/README.md
+++ b/acurl/valgrind/README.md
@@ -1,0 +1,13 @@
+Command for running valgrind from within this directory:
+
+```
+PYTHONMALLOC=malloc valgrind --tool=memcheck --suppressions=valgrind-python.supp \
+    --leak-check=full --show-leak-kinds=all -- \
+    python leak_check.py |& tee malloc.out
+```
+
+Make sure you do `pip install -e ../acurl` after making code changes as
+these will not automatically be compiled/picked up.
+
+The valgrind-python.supp file comes from the python repo:
+<https://svn.python.org/projects/python/trunk/Misc/valgrind-python.supp>

--- a/acurl/valgrind/leak_check.py
+++ b/acurl/valgrind/leak_check.py
@@ -1,0 +1,26 @@
+import asyncio
+import acurl
+import gc
+
+async def main():
+    el = acurl.CurlWrapper(asyncio.get_running_loop())
+    session = el.session()
+
+    # Sometimes a leak won't be apparent when running a line of code just
+    # once, due to the vagaries of gc etc.  A useful tactic is to run a
+    # possibly leaky operation 100 times, and then look for things in the
+    # valgrind output that are lost or possibly lost 100 (or possibly 99)
+    # times -- that's an indication the allocations come from the code run in
+    # the loop.
+
+    # for _ in range(100):
+    #     r = await session.get("http://example.com")
+
+    # But the simplest case is just to run the code once
+    r = await session.get("http://example.com")
+
+if __name__ == "__main__":
+    asyncio.run(main())
+    # Run the GC before exiting just to ensure that all possible collections
+    # are done.
+    gc.collect()

--- a/acurl/valgrind/valgrind-python.supp
+++ b/acurl/valgrind/valgrind-python.supp
@@ -1,0 +1,391 @@
+#
+# This is a valgrind suppression file that should be used when using valgrind.
+#
+#  Here's an example of running valgrind:
+#
+#	cd python/dist/src
+#	valgrind --tool=memcheck --suppressions=Misc/valgrind-python.supp \
+#		./python -E -tt ./Lib/test/regrtest.py -u bsddb,network
+#
+# You must edit Objects/obmalloc.c and uncomment Py_USING_MEMORY_DEBUGGER
+# to use the preferred suppressions with Py_ADDRESS_IN_RANGE.
+#
+# If you do not want to recompile Python, you can uncomment
+# suppressions for PyObject_Free and PyObject_Realloc.
+#
+# See Misc/README.valgrind for more information.
+
+# all tool names: Addrcheck,Memcheck,cachegrind,helgrind,massif
+{
+   ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Addr4
+   fun:Py_ADDRESS_IN_RANGE
+}
+
+{
+   ADDRESS_IN_RANGE/Invalid read of size 4
+   Memcheck:Value4
+   fun:Py_ADDRESS_IN_RANGE
+}
+
+{
+   ADDRESS_IN_RANGE/Invalid read of size 8 (x86_64 aka amd64)
+   Memcheck:Value8
+   fun:Py_ADDRESS_IN_RANGE
+}
+
+{
+   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
+   Memcheck:Cond
+   fun:Py_ADDRESS_IN_RANGE
+}
+
+#
+# Leaks (including possible leaks)
+#    Hmmm, I wonder if this masks some real leaks.  I think it does.
+#    Will need to fix that.
+#
+
+{
+   Suppress leaking the GIL.  Happens once per process, see comment in ceval.c.
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_allocate_lock
+   fun:PyEval_InitThreads
+}
+
+{
+   Suppress leaking the GIL after a fork.
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_allocate_lock
+   fun:PyEval_ReInitThreads
+}
+
+{
+   Suppress leaking the autoTLSkey.  This looks like it shouldn't leak though.
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_create_key
+   fun:_PyGILState_Init
+   fun:Py_InitializeEx
+   fun:Py_Main
+}
+
+{
+   Hmmm, is this a real leak or like the GIL?
+   Memcheck:Leak
+   fun:malloc
+   fun:PyThread_ReInitTLS
+}
+
+{
+   Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:realloc
+   fun:_PyObject_GC_Resize
+   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+}
+
+{
+   Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:malloc
+   fun:_PyObject_GC_New
+   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+}
+
+{
+   Handle PyMalloc confusing valgrind (possibly leaked)
+   Memcheck:Leak
+   fun:malloc
+   fun:_PyObject_GC_NewVar
+   fun:COMMENT_THIS_LINE_TO_DISABLE_LEAK_WARNING
+}
+
+#
+# Non-python specific leaks
+#
+
+{
+   Handle pthread issue (possibly leaked)
+   Memcheck:Leak
+   fun:calloc
+   fun:allocate_dtv
+   fun:_dl_allocate_tls_storage
+   fun:_dl_allocate_tls
+}
+
+{
+   Handle pthread issue (possibly leaked)
+   Memcheck:Leak
+   fun:memalign
+   fun:_dl_allocate_tls_storage
+   fun:_dl_allocate_tls
+}
+
+###{
+###   ADDRESS_IN_RANGE/Invalid read of size 4
+###   Memcheck:Addr4
+###   fun:PyObject_Free
+###}
+###
+###{
+###   ADDRESS_IN_RANGE/Invalid read of size 4
+###   Memcheck:Value4
+###   fun:PyObject_Free
+###}
+###
+###{
+###   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
+###   Memcheck:Cond
+###   fun:PyObject_Free
+###}
+
+###{
+###   ADDRESS_IN_RANGE/Invalid read of size 4
+###   Memcheck:Addr4
+###   fun:PyObject_Realloc
+###}
+###
+###{
+###   ADDRESS_IN_RANGE/Invalid read of size 4
+###   Memcheck:Value4
+###   fun:PyObject_Realloc
+###}
+###
+###{
+###   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
+###   Memcheck:Cond
+###   fun:PyObject_Realloc
+###}
+
+###
+### All the suppressions below are for errors that occur within libraries
+### that Python uses.  The problems to not appear to be related to Python's
+### use of the libraries.
+###
+
+{
+   Generic ubuntu ld problems
+   Memcheck:Addr8
+   obj:/lib/ld-2.4.so
+   obj:/lib/ld-2.4.so
+   obj:/lib/ld-2.4.so
+   obj:/lib/ld-2.4.so
+}
+
+{
+   Generic gentoo ld problems
+   Memcheck:Cond
+   obj:/lib/ld-2.3.4.so
+   obj:/lib/ld-2.3.4.so
+   obj:/lib/ld-2.3.4.so
+   obj:/lib/ld-2.3.4.so
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Param
+   write(buf)
+   fun:write
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_close
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Value8
+   fun:memmove
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_store
+   fun:dbm_ass_sub
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Cond
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_store
+   fun:dbm_ass_sub
+}
+
+{
+   DBM problems, see test_dbm
+   Memcheck:Cond
+   fun:memmove
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   obj:/usr/lib/libdb1.so.2
+   fun:dbm_store
+   fun:dbm_ass_sub
+}
+
+{
+   GDBM problems, see test_gdbm
+   Memcheck:Param
+   write(buf)
+   fun:write
+   fun:gdbm_open
+
+}
+
+{
+   ZLIB problems, see test_gzip
+   Memcheck:Cond
+   obj:/lib/libz.so.1.2.3
+   obj:/lib/libz.so.1.2.3
+   fun:deflate
+}
+
+{
+   Avoid problems w/readline doing a putenv and leaking on exit
+   Memcheck:Leak
+   fun:malloc
+   fun:xmalloc
+   fun:sh_set_lines_and_columns
+   fun:_rl_get_screen_size
+   fun:_rl_init_terminal_io
+   obj:/lib/libreadline.so.4.3
+   fun:rl_initialize
+}
+
+###
+### These occur from somewhere within the SSL, when running
+###  test_socket_sll.  They are too general to leave on by default.
+###
+###{
+###   somewhere in SSL stuff
+###   Memcheck:Cond
+###   fun:memset
+###}
+###{
+###   somewhere in SSL stuff
+###   Memcheck:Value4
+###   fun:memset
+###}
+###
+###{
+###   somewhere in SSL stuff
+###   Memcheck:Cond
+###   fun:MD5_Update
+###}
+###
+###{
+###   somewhere in SSL stuff
+###   Memcheck:Value4
+###   fun:MD5_Update
+###}
+
+#
+# All of these problems come from using test_socket_ssl
+#
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_bin2bn
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_num_bits_word
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:BN_num_bits_word
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_mod_exp_mont_word
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BN_mod_exp_mont
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Param
+   write(buf)
+   fun:write
+   obj:/usr/lib/libcrypto.so.0.9.7
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:RSA_verify
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:RSA_verify
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:DES_set_key_unchecked
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:DES_encrypt2
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   obj:/usr/lib/libssl.so.0.9.7
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   obj:/usr/lib/libssl.so.0.9.7
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:BUF_MEM_grow_clean
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:memcpy
+   fun:ssl3_read_bytes
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Cond
+   fun:SHA1_Update
+}
+
+{
+   from test_socket_ssl
+   Memcheck:Value4
+   fun:SHA1_Update
+}
+
+

--- a/mite_http/__init__.py
+++ b/mite_http/__init__.py
@@ -16,7 +16,6 @@ class AcurlSessionWrapper:
         self.additional_metrics = {}
 
     def __getattr__(self, attrname):
-
         try:
             r = object.__getattr__(self, attrname)
             return r

--- a/test/perf/run-perftest.sh
+++ b/test/perf/run-perftest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd `git rev-parse --show-toplevel`
 
@@ -9,9 +9,25 @@ mkdir -p test/perf/output
 #     exit 1
 # fi
 
+# If running under docker, then the image will be run in the system's uid
+# namespace.  That means that we need to switch the user under which it runs,
+# so that the perf test output data that it's creating in the test/perf/output
+# directory is owned by the current user and not root.  On other container
+# runtimes, such as podman, the container will be run in a new uid namespace
+# where root (uid 0) is actually the current user.  Under that circumstance,
+# the ownership of the output files works correctly, and changing the user id
+# of the running container is undesirable because that results (in the host
+# uid ns) in the files being owned by a nonexistent user.  This conditional
+# accounts for the difference.
+if docker --version | grep -q podman; then
+    uid_arg=""
+else
+    uid_arg="--user `id -u`"
+fi
+
 docker build -t mite-perftest -f Dockerfile.perftest . || exit 1
 
-docker run --user `id -u` --rm \
+docker run --rm $uid_arg \
        --mount "type=bind,source=`pwd`/test/perf/output,destination=/output" \
        --env MITE_PERFTEST_OUT=/output \
        mite-perftest python test/perf/perftest.py \

--- a/test/test_mite_http.py
+++ b/test/test_mite_http.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from unittest.mock import patch
 
@@ -89,11 +90,6 @@ async def test_decorator_eventloop_memoization():
     class MockContext:
         pass
 
-    with patch("mite_http.asyncio") as asyncio_mock:
-        # slightly tricksy: we only patch the copy of get_event_loop that is
-        # imported into mite_http, so that other code continues to function
-        # normally
-        asyncio_mock.get_event_loop.return_value = "foo"
-        await foo(MockContext())
+    await foo(MockContext())
 
-    assert "foo" in SessionPool._session_pools
+    assert asyncio.get_running_loop() in SessionPool._session_pools


### PR DESCRIPTION
Here are the fixes and things we talked about a couple weeks ago.  I've split the commits up by purpose, and also ordered them into blocks for ease of reviewing/digesting.

- Commits up to 920d (inclusive) are docs/tooling/cosmetic
- f2be is a fix to the mite test suite removing a questionable mock that would cause the new acurl code to trip
- 73bf and 665c are documentation fixes inside the acurl code
- 30c0 and 7c18 are code changes unrelated to mem leak stuff
- and finally, 7d57 to the end are mem leak fixes