### PR TITLE
Flush the raw message after writing

### DIFF
--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -153,6 +153,10 @@ def test_scenarios(test_name, opts, scenarios, config_manager):
     # Run one last report before exiting
     controller.report(receiver.recieve)
     has_error = http_stats_output is not None and http_stats_output.error_total > 0
+
+    # Ensure any open files get closed
+    del receiver._raw_listeners
+
     sys.exit(int(has_error))
 
 

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -156,6 +156,7 @@ def test_scenarios(test_name, opts, scenarios, config_manager):
 
     # Ensure any open files get closed
     del receiver._raw_listeners
+    del receiver._listeners
 
     sys.exit(int(has_error))
 

--- a/mite/collector.py
+++ b/mite/collector.py
@@ -32,6 +32,9 @@ class Collector:
         self._file_counter = count()
         self._rotate_current_file()
 
+    def __del__(self):
+        self._current.close()
+
     @property
     def _current_fn(self):
         return os.path.join(self._target_dir, "current")
@@ -53,7 +56,6 @@ class Collector:
             self._current.write(json.dumps(decoded).encode() + b"\n")
         else:
             self._current.write(msg)
-        self._current.flush()
 
     def _rotate_current_file(self):
         self._msg_count = 0

--- a/mite/collector.py
+++ b/mite/collector.py
@@ -18,9 +18,9 @@ class Collector:
         filter_fn=None,
         use_json=False,
     ):
-        logger.info('Initializing collector')
+        logger.info("Initializing collector")
         if target_dir is None:
-            target_dir = 'collector_data'
+            target_dir = "collector_data"
         self._target_dir = os.path.abspath(target_dir)
         self._roll_after = roll_after
         os.makedirs(self._target_dir, exist_ok=True)
@@ -34,11 +34,11 @@ class Collector:
 
     @property
     def _current_fn(self):
-        return os.path.join(self._target_dir, 'current')
+        return os.path.join(self._target_dir, "current")
 
     @property
     def _current_st_fn(self):
-        return os.path.join(self._target_dir, 'current_start_time')
+        return os.path.join(self._target_dir, "current_start_time")
 
     def process_raw_message(self, raw):
         self._msg_count += 1
@@ -53,6 +53,7 @@ class Collector:
             self._current.write(json.dumps(decoded).encode() + b"\n")
         else:
             self._current.write(msg)
+        self._current.flush()
 
     def _rotate_current_file(self):
         self._msg_count = 0
@@ -61,14 +62,14 @@ class Collector:
             self._current.close()
 
         if os.path.isfile(self._current_fn):
-            logger.debug('rotating existing current file %s', self._current_fn)
+            logger.debug("rotating existing current file %s", self._current_fn)
             with open(self._current_st_fn) as f:
                 start_time = f.read()
             end_time = int(time.time())
             c = next(self._file_counter)
             fn = os.path.join(
                 self._target_dir,
-                '_'.join(
+                "_".join(
                     str(x)
                     for x in (
                         start_time,
@@ -78,10 +79,10 @@ class Collector:
                     )
                 ),
             )
-            logger.info('moving old current %s to %s', self._current_fn, fn)
+            logger.info("moving old current %s to %s", self._current_fn, fn)
             os.rename(self._current_fn, fn)
 
-        with open(self._current_st_fn, 'w') as f:
+        with open(self._current_st_fn, "w") as f:
             f.write(str(int(time.time())))
 
-        self._current = open(self._current_fn, 'wb')
+        self._current = open(self._current_fn, "wb")


### PR DESCRIPTION
Occasionally when sending a message it would not write to the collector file. The buffered writer is only written to under the conditions [[0](https://docs.python.org/3/library/io.html#io.BufferedWriter)]: 
 - when the buffer gets too small for all pending data;
 - when flush() is called;
 - when a seek() is requested (for BufferedRandom objects);
 - when the BufferedWriter object is closed or destroyed.

The odd message would get missed, I believe due to the `Collector` object being destroyed before a `close` is called on our writer object. This PR ensures a `flush` is called after every write.