### PR TITLE
ipb 12210

### DIFF
--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -286,6 +286,8 @@ def setup_logging(opts):
     # add the journey_logging attribute to the object
     # default is False´
     journey_logging = opts.get("--journey-logging", False)
+    if journey_logging is not False:
+        journey_logging = True
     setattr(logging, "journey_logging", journey_logging)
 
 

--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -283,12 +283,6 @@ def setup_logging(opts):
         level=opts["--log-level"],
         format="[%(asctime)s] <%(levelname)s> [%(name)s] [%(pathname)s:%(lineno)d %(funcName)s] %(message)s",
     )
-    # add the journey_logging attribute to the object
-    # default is False´
-    journey_logging = opts.get("--journey-logging", False)
-    if journey_logging is not False:
-        journey_logging = True
-    setattr(logging, "journey_logging", journey_logging)
 
 
 def configure_python_path(opts):

--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -66,6 +66,7 @@ Options:
     --logging-webhook=URL                   URL of an HTTP server to log test runs to
     --message-processors=PROCESSORS         Classes to connect to the message bus for local testing [default: mite.logoutput:HttpStatsOutput,mite.logoutput:MsgOutput]
     --prettify-timestamps                   Reformat unix timestamps to human readable dates
+    --journey-logging                       Log errors on a per journey basis
 """
 import asyncio
 import logging
@@ -282,6 +283,10 @@ def setup_logging(opts):
         level=opts["--log-level"],
         format="[%(asctime)s] <%(levelname)s> [%(name)s] [%(pathname)s:%(lineno)d %(funcName)s] %(message)s",
     )
+    # add the journey_logging attribute to the object
+    # default is False´
+    journey_logging = opts.get("--journey-logging", False)
+    setattr(logging, "journey_logging", journey_logging)
 
 
 def configure_python_path(opts):

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -71,7 +71,7 @@ def _setup_msg_processors(receiver, opts):
     receiver.add_raw_listener(collector.process_raw_message)
 
     extra_processors = [
-        spec_import(x)() for x in opts["--message-processors"].split(",") if x
+        spec_import(x)(opts) for x in opts["--message-processors"].split(",") if x
     ]
     for processor in extra_processors:
         if hasattr(processor, "process_message"):
@@ -132,7 +132,7 @@ def test_scenarios(test_name, opts, scenarios, config_manager):
     controller = Controller(test_name, scenario_manager, config_manager)
     transport = DirectRunnerTransport(controller)
     receiver = DirectReciever()
-    debug_message_output = DebugMessageOutput()
+    debug_message_output = DebugMessageOutput(opts)
     receiver.add_listener(debug_message_output.process_message)
     _setup_msg_processors(receiver, opts)
     http_stats_output = _get_http_stats_output(receiver)

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -79,7 +79,7 @@ class GenericStatsOutput:
         dt = t - self._start_t
         self._resp_time_recent.sort()
         self._logger.info(f"Total> #Reqs:{self._req_total} #Errs:{self._error_total}")
-        # only output journey logs if the --journey_logging switch is set 
+        # only output journey logs if the --journey_logging switch is set
         if self._journey_logging:
             for k, v in self._error_journeys.items():
                 self._logger.info(f"Total errors for {k} :{v}")

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -1,7 +1,6 @@
 import logging
 import math
 import time
-
 from collections import defaultdict
 
 

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -113,11 +113,11 @@ class GenericStatsOutput:
             self._error_recent += 1
             # get the name of the erroring journey
             journey_name = message.get("journey")
-            if journey_name != None:
+            if journey_name is not None:
                 # the dictionary stores how many times
                 # the journey has errored
                 journey_error = self._error_journeys.get(journey_name)
-                if journey_error == None:
+                if journey_error is None:
                     self._error_journeys[journey_name] = 1
                 else:
                     journey_error += 1

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,0 +1,19 @@
+import pytest
+import logging
+from mite.__main__ import setup_logging
+
+def test_journey_logging():
+    optsTrue = {
+        "--log-level": "DEBUG",
+        "--journey-logging": ""
+    }
+ 
+    optsFalse = {
+        "--log-level": "DEBUG"
+    }
+
+    setup_logging(optsTrue)
+    assert logging.__dict__.get("journey_logging") == True
+
+    setup_logging(optsFalse)
+    assert logging.__dict__.get("journey_logging") == False

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,4 +1,5 @@
 import logging
+
 from mite.__main__ import setup_logging
 
 

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -2,15 +2,11 @@ import pytest
 import logging
 from mite.__main__ import setup_logging
 
+
 def test_journey_logging():
-    optsTrue = {
-        "--log-level": "DEBUG",
-        "--journey-logging": ""
-    }
- 
-    optsFalse = {
-        "--log-level": "DEBUG"
-    }
+    optsTrue = {"--log-level": "DEBUG", "--journey-logging": ""}
+
+    optsFalse = {"--log-level": "DEBUG"}
 
     setup_logging(optsTrue)
     assert logging.__dict__.get("journey_logging") == True

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,15 +1,13 @@
-import logging
-
-from mite.__main__ import setup_logging
+from mite.logoutput import HttpStatsOutput
 
 
 def test_journey_logging():
-    optsTrue = {"--log-level": "DEBUG", "--journey-logging": ""}
+    optsTrue = {"--journey-logging": ""}
 
-    optsFalse = {"--log-level": "DEBUG"}
+    optsFalse = {}
 
-    setup_logging(optsTrue)
-    assert logging.__dict__.get("journey_logging") is True
+    h = HttpStatsOutput(optsTrue)
+    assert h._journey_logging is True
 
-    setup_logging(optsFalse)
-    assert logging.__dict__.get("journey_logging") is False
+    h = HttpStatsOutput(optsFalse)
+    assert h._journey_logging is False

--- a/test/test_logging.py
+++ b/test/test_logging.py
@@ -1,4 +1,3 @@
-import pytest
 import logging
 from mite.__main__ import setup_logging
 
@@ -9,7 +8,7 @@ def test_journey_logging():
     optsFalse = {"--log-level": "DEBUG"}
 
     setup_logging(optsTrue)
-    assert logging.__dict__.get("journey_logging") == True
+    assert logging.__dict__.get("journey_logging") is True
 
     setup_logging(optsFalse)
-    assert logging.__dict__.get("journey_logging") == False
+    assert logging.__dict__.get("journey_logging") is False


### PR DESCRIPTION
Improve CoreP data creation
mite now supports the --journey-logging flag, when this is used, journeys that error will be logged, along with the number of times each journey has errored. the log output is something like the following
[2021-11-03 15:09:22,236] <INFO> [Http Stats] [/Users/jht27/Documents/docker.d/jah.d/id-mite-nft/mite/mite/logoutput.py:78 print_output] Total> #Reqs:20 #Errs:12552

[2021-11-03 15:09:22,236] <INFO> [Http Stats] [/Users/jht27/Documents/docker.d/jah.d/id-mite-nft/mite/mite/logoutput.py:80 print_output] Total errors for mite.examplejah:journeyjah4 :6263.    <---- journey error

[2021-11-03 15:09:22,236] <INFO> [Http Stats] [/Users/jht27/Documents/docker.d/jah.d/id-mite-nft/mite/mite/logoutput.py:80 print_output] Total errors for mite.examplejah:journeyjah3 :6289.    <---- journey error 

[2021-11-03 15:09:22,236] <INFO> [Http Stats] [/Users/jht27/Documents/docker.d/jah.d/id-mite-nft/mite/mite/logoutput.py:81 print_output] Last 2 Secs> #Reqs:20 #Errs:12552 Req/S:10.0 min:0.044937 25%:0.048043 50%:0.150933 75%:0.232211 90%:0.254889 99%:0.259194 99.9%:0.259207 max:0.259208