### PR TITLE
Add a new option to set an error threshold in the scenario command

### DIFF
--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -67,6 +67,7 @@ Options:
     --message-processors=PROCESSORS         Classes to connect to the message bus for local testing [default: mite.logoutput:HttpStatsOutput,mite.logoutput:MsgOutput]
     --prettify-timestamps                   Reformat unix timestamps to human readable dates
     --journey-logging                       Log errors on a per journey basis
+    --max-errors-threshold=THRESHOLD        Set the maximum amount of error accepted before set exit stauts to 1 [default: 0]
 """
 import asyncio
 import logging

--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -67,7 +67,7 @@ Options:
     --message-processors=PROCESSORS         Classes to connect to the message bus for local testing [default: mite.logoutput:HttpStatsOutput,mite.logoutput:MsgOutput]
     --prettify-timestamps                   Reformat unix timestamps to human readable dates
     --journey-logging                       Log errors on a per journey basis
-    --max-errors-threshold=THRESHOLD        Set the maximum amount of error accepted before set exit stauts to 1 [default: 0]
+    --max-errors-threshold=THRESHOLD        Set the maximum number of errors accepted before setting exit status to 1 [default: 0]
 """
 import asyncio
 import logging

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -152,7 +152,9 @@ def test_scenarios(test_name, opts, scenarios, config_manager):
     loop.run_until_complete(asyncio.wait(coroutines, return_when=asyncio.FIRST_COMPLETED))
     # Run one last report before exiting
     controller.report(receiver.recieve)
-    has_error = http_stats_output is not None and http_stats_output.error_total > 0
+    has_error = http_stats_output is not None and http_stats_output.error_total > int(
+        opts.get("--max-errors-threshold")
+    )
 
     # Ensure any open files get closed
     del receiver._raw_listeners


### PR DESCRIPTION
Sometimes when running a big amount of journeys a single error can be irrelevant and making fail the whole job can be annoying. This will allow mite to set an exit status of 0 even if we got some error if the number will be lower than the set threshold.