### PR TITLE
Fix HTTP 100 test

### DIFF
--- a/acurl_ng/tests/test_response_ng.py
+++ b/acurl_ng/tests/test_response_ng.py
@@ -41,7 +41,9 @@ async def test_response_headers_with_HTTP_100(httpserver, acurl_session_ng):
     httpserver.expect_request("/foo").respond_with_response(
         Response(response="", status=200, headers=hdrs)
     )
-    r = await acurl_session_ng.get(httpserver.url_for("/foo"), headers={"Expect": "100-continue"})
+    r = await acurl_session_ng.get(
+        httpserver.url_for("/foo"), headers={"Expect": "100-continue"}
+    )
 
     assert "Foo" in r.headers
     assert r.headers["Foo"] == "bar"

--- a/acurl_ng/tests/test_response_ng.py
+++ b/acurl_ng/tests/test_response_ng.py
@@ -1,11 +1,6 @@
-import asyncio
-from functools import partial
-
 import pytest
 from werkzeug.datastructures import Headers
 from werkzeug.wrappers import Response
-
-import acurl_ng
 
 
 @pytest.mark.asyncio
@@ -47,39 +42,6 @@ async def test_response_headers_with_HTTP_100(httpserver, acurl_session_ng):
 
     assert "Foo" in r.headers
     assert r.headers["Foo"] == "bar"
-
-
-# FIXME: This test hangs after the introduction of AcurlError handling because curl returns CURLE_RECV_ERROR (56)
-@pytest.mark.skip
-async def test_response_headers_with_multiple_HTTP_100(acurl_session_ng):
-    # It's unclear if this can happen. It doesn't sound like it should, but
-    # there's documentation of it happening in IIS at least:
-    # https://stackoverflow.com/questions/22818059/several-100-continue-received-from-the-server
-    body = b"".join(
-        (
-            b"HTTP/1.1 100 Continue\r\n",
-            b"\r\n",
-            b"HTTP/1.1 100 Continue\r\n",
-            b"\r\n",
-            b"HTTP/1.1 200 OK\r\n",
-            b"Foo: bar\r\n",
-            b"\r\n",
-        )
-    )
-    server = await asyncio.start_server(
-        partial(connected_cb, body), host="127.0.0.1", port=10764
-    )
-    await server.start_serving()
-
-    async def go():
-        r = await acurl_session_ng.get("http://localhost:10764/foo")
-        server.close()
-        return r
-
-    results = await asyncio.gather(go(), server.serve_forever(), return_exceptions=True)
-    resp = [x for x in results if isinstance(x, acurl_ng._Response)][0]
-    assert "Foo" in resp.headers
-    assert resp.headers["Foo"] == "bar"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes the broken tests from #224


## `test_response_headers_with_HTTP_100` test

Instead of creating a dummy http server, it's using pytest-httpserver and sending the `Expect: 100-continue` header.

We can confirm that we get a "100 Continue" followed by "200 OK" by looking at `r.header`:

```HTTP/1.1 100 Continue\r\n\r\nHTTP/1.0 200 OK\r\nFoo: bar\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: 0\r\nServer: Werkzeug/2.0.1 Python/3.9.9\r\nDate: Wed, 24 Nov 2021 11:40:31 GMT\r\n\r\n```

## `test_response_headers_with_multiple_HTTP_100` test

Removed this test. `CURLINFO_RESPONSE_CODE` should always have the last received response code, so we can be pretty confident we're safe against this corner case.