### PR TITLE
returning an empty list instead of nonetype

### DIFF
--- a/mite_selenium/__init__.py
+++ b/mite_selenium/__init__.py
@@ -138,7 +138,7 @@ class _SeleniumWrapper:
             logger.error(
                 f"Performance entries did not return the expected count: expected 1 - actual {len(entries)}"
             )
-            return
+            return []
         else:
             return entries[:expected]
 


### PR DESCRIPTION
changing the return statement in `_extract_entries` to return an empty list `[]` instead of `noneType`.