### PR TITLE
IPB-16472 Fix Jenkins Slave Image Rust issue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,8 @@
 [metadata]
 name = mite
 
+# TODO - Update (or remove) the Selenium version when migrating to v4. The version is explicitly defined
+#        as less than 4 as here are backward compatibility issues with Rust from version 4 on
 [options]
 install_requires =
     acurl
@@ -11,7 +13,7 @@ install_requires =
     msgpack
     nanomsg
     pyzmq
-    selenium
+    selenium<4
     uvloop
     websockets
 setup_requires = pytest-runner


### PR DESCRIPTION
Using the latest version of Selenium causes incompatibility issues with Rust. Setting the version to less than 4 prevents this issue. 

Note that this will need to be revised when we upgrade to Selenium 4. The card for that work - https://agile.at.sky/browse/IPB-15616 - has been updated to capture this.