### PR TITLE
docker fixes etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,24 @@
 Mite is a load testing framework with distributed components written in Python.
 Requests are executed asynchronously, allowing large throughput from relatively small infrastructure.
 
-To install mite, run `pip install mite`.  This requires that you have
-libcurl installed on your system (including C header files for
-development, which are often distrbuted separately from the shared
-libraries).  On ubuntu, this can be accomplished with the command:
+## Installation
+
+```bash
+python3 -m venv ~/.virtualenvs/mite
+source ~/.virtualenvs/mite/bin/activate
+
+pip install -r requirements.txt
+```
+
+
+This requires that you have libcurl installed on your system (including C header files for development, which are often distributed separately from the shared libraries).  On Ubuntu, this can be accomplished with the command:
 
 ```
 sudo apt install libcurl4 libcurl4-openssl-dev
 ```
-
 (NB we recommend using a version of libcurl linked against openssl
 rather than gnutls, since the latter has memory leak problems)
+
 
 You can also use the dockerfile included in this repository to run
 mite.  In order to get a shell in a container with mite installed, run

--- a/docker_compose.yml
+++ b/docker_compose.yml
@@ -10,6 +10,12 @@ services:
     command: ["mite", "runner", "--controller-socket=tcp://controller:14301", "--message-socket=tcp://duplicator:14302"]
     deploy:
       replicas: 2
+    volumes:
+      - type: bind
+        source: ./local
+        target: /mite/local
+    environment:
+      - API_URL=http://apiserver:8000/
   duplicator:
     image: mite:latest
     command: ["mite", "duplicator", "--message-socket=tcp://0.0.0.0:14302", "tcp://0.0.0.0:14303"]
@@ -17,7 +23,7 @@ services:
     image: mite:latest
     command: ["mite", "stats", "--stats-in-socket=tcp://duplicator:14303", "--stats-out-socket=tcp://prometheus_exporter:14305", "--stats-include-processors=mite,mite_http"]
     deploy:
-      replicas: 2
+      replicas: 1
   prometheus_exporter:
     image: mite:latest
     command: ["mite", "prometheus_exporter", "--stats-out-socket=tcp://0.0.0.0:14305", "--web-address=0.0.0.0:9301"]
@@ -26,6 +32,12 @@ services:
     command: ["mite", "controller", "--controller-socket=tcp://0.0.0.0:14301", "--message-socket=tcp://duplicator:14302", "local.demo:scenario"]
     depends_on:
       - apiserver
+    volumes:
+      - type: bind
+        source: ./local
+        target: /mite/local
+    environment:
+      - API_URL=http://apiserver:8000/
   prometheus:
     build:
       context: .

--- a/docker_compose_monitoring.yml
+++ b/docker_compose_monitoring.yml
@@ -1,26 +1,22 @@
-version: '3.5'
+version: '3.9'
 services:
   prometheus:
-    image: "prom/prometheus:v2.12.0"
-    user: "1000"
-    network_mode: "host"
+    image: "prom/prometheus:latest"
     ports:
       - "9090:9090"
     volumes:
       - ./prometheus/prometheus_config_template.yml:/etc/prometheus/prometheus.yml
-      - /var/prometheus:/prometheus
+      # - /var/prometheus:/prometheus
     command: ["--config.file=/etc/prometheus/prometheus.yml",
-              "--storage.tsdb.path=/prometheus",
-              "--web.console.libraries=/usr/share/prometheus/console_libraries",
-              "--web.console.templates=/usr/share/prometheus/consoles",
+              # "--storage.tsdb.path=/prometheus",
+              # "--web.console.libraries=/usr/share/prometheus/console_libraries",
+              # "--web.console.templates=/usr/share/prometheus/consoles",
               "--storage.tsdb.retention.size=10GB"]
-    # TODO: alertmanager; I (AWE) have a config for this somewhere else
   grafana:
-    image: "grafana/grafana:6.3.5"
-    network_mode: "host"
-    user: "1000"
+    build:
+      context: .
+      dockerfile: ./grafana/Dockerfile
     ports:
-      - "3000:3000"
+      - 3000:3000
     depends_on:
       - prometheus
-

--- a/docker_compose_monitoring.yml
+++ b/docker_compose_monitoring.yml
@@ -3,14 +3,14 @@ services:
   prometheus:
     image: "prom/prometheus:latest"
     ports:
-      - "9090:9090"
+      - 9090:9090
     volumes:
       - ./prometheus/prometheus_config_template.yml:/etc/prometheus/prometheus.yml
       # - /var/prometheus:/prometheus
     command: ["--config.file=/etc/prometheus/prometheus.yml",
               # "--storage.tsdb.path=/prometheus",
-              # "--web.console.libraries=/usr/share/prometheus/console_libraries",
-              # "--web.console.templates=/usr/share/prometheus/consoles",
+              "--web.console.libraries=/usr/share/prometheus/console_libraries",
+              "--web.console.templates=/usr/share/prometheus/consoles",
               "--storage.tsdb.retention.size=10GB"]
   grafana:
     build:

--- a/grafana/provisioning/dashboards/mite_docker.json
+++ b/grafana/provisioning/dashboards/mite_docker.json
@@ -31,6 +31,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
+        "datasource": "prometheus",
         "fieldConfig": {
           "defaults": {
             "links": []
@@ -75,10 +76,6 @@
         "steppedLine": true,
         "targets": [
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "EWbR14a7z"
-            },
             "exemplar": true,
             "expr": "(histogram_quantile(0.99999, sum without(job)(rate(mite_http_response_time_seconds_bucket[10s])))) < 60",
             "format": "time_series",
@@ -90,10 +87,6 @@
             "step": 1
           },
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "EWbR14a7z"
-            },
             "exemplar": true,
             "expr": "(histogram_quantile(0.9999, sum without(job)(rate(mite_http_response_time_seconds_bucket[10s])))) < 60",
             "format": "time_series",
@@ -105,10 +98,6 @@
             "step": 1
           },
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "EWbR14a7z"
-            },
             "exemplar": true,
             "expr": "(histogram_quantile(0.999, sum without(job)(rate(mite_http_response_time_seconds_bucket[10s])))) < 60",
             "format": "time_series",
@@ -120,10 +109,6 @@
             "step": 1
           },
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "EWbR14a7z"
-            },
             "exemplar": true,
             "expr": "(histogram_quantile(0.99, sum without(job)(rate(mite_http_response_time_seconds_bucket[10s])))) < 60\n",
             "format": "time_series",
@@ -135,10 +120,6 @@
             "step": 1
           },
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "EWbR14a7z"
-            },
             "exemplar": true,
             "expr": "(histogram_quantile(0.95, sum without(job)(rate(mite_http_response_time_seconds_bucket[10s])))) < 60",
             "format": "time_series",
@@ -148,10 +129,6 @@
             "refId": "H"
           },
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "EWbR14a7z"
-            },
             "exemplar": true,
             "expr": "(histogram_quantile(0.9, sum without(job)(rate(mite_http_response_time_seconds_bucket[10s])))) < 60",
             "format": "time_series",
@@ -162,10 +139,6 @@
             "step": 1
           },
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "EWbR14a7z"
-            },
             "exemplar": true,
             "expr": "(histogram_quantile(0.75, sum without(job)(rate(mite_http_response_time_seconds_bucket[10s])))) < 60",
             "format": "time_series",
@@ -176,10 +149,6 @@
             "step": 1
           },
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "EWbR14a7z"
-            },
             "exemplar": true,
             "expr": "(histogram_quantile(0.5, sum without(job)(rate(mite_http_response_time_seconds_bucket[10s])))) < 60",
             "format": "time_series",
@@ -190,10 +159,6 @@
             "step": 1
           },
           {
-            "datasource": {
-              "type": "prometheus",
-              "uid": "EWbR14a7z"
-            },
             "exemplar": true,
             "expr": "(histogram_quantile(0.25, sum without(job)(rate(mite_http_response_time_seconds_bucket[10s])))) < 60",
             "format": "time_series",
@@ -243,10 +208,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "EWbR14a7z"
-        },
+        "datasource": "prometheus",
         "fieldConfig": {
           "defaults": {
             "links": []
@@ -346,10 +308,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "EWbR14a7z"
-        },
+        "datasource": "prometheus",
         "fieldConfig": {
           "defaults": {
             "links": []
@@ -440,10 +399,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "EWbR14a7z"
-        },
+        "datasource": "prometheus",
         "fieldConfig": {
           "defaults": {
             "links": []
@@ -533,10 +489,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "EWbR14a7z"
-        },
+        "datasource": "prometheus",
         "fieldConfig": {
           "defaults": {
             "links": []
@@ -629,10 +582,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "EWbR14a7z"
-        },
+        "datasource": "prometheus",
         "fieldConfig": {
           "defaults": {
             "links": []
@@ -723,10 +673,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "EWbR14a7z"
-        },
+        "datasource": "prometheus",
         "fieldConfig": {
           "defaults": {
             "links": []
@@ -812,10 +759,7 @@
       },
       {
         "columns": [],
-        "datasource": {
-          "type": "prometheus",
-          "uid": "EWbR14a7z"
-        },
+        "datasource": "prometheus",
         "fontSize": "100%",
         "gridPos": {
           "h": 14,
@@ -872,10 +816,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "EWbR14a7z"
-        },
+        "datasource": "prometheus",
         "fieldConfig": {
           "defaults": {
             "links": []
@@ -954,10 +895,7 @@
       },
       {
         "columns": [],
-        "datasource": {
-          "type": "prometheus",
-          "uid": "EWbR14a7z"
-        },
+        "datasource": "prometheus",
         "fontSize": "100%",
         "gridPos": {
           "h": 13,
@@ -1033,10 +971,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": {
-          "type": "prometheus",
-          "uid": "EWbR14a7z"
-        },
+        "datasource": "prometheus",
         "fieldConfig": {
           "defaults": {
             "links": []
@@ -1123,7 +1058,7 @@
         }
       }
     ],
-    "refresh": "",
+    "refresh": "10s",
     "schemaVersion": 34,
     "style": "dark",
     "tags": [],

--- a/local/README.md
+++ b/local/README.md
@@ -8,7 +8,7 @@ The docker-compose is setup to be able to run a separate docker container for ea
 To run mite performance test against an app, the `apiserver` container in the docker-compose.yml can be exchanged with any docker image
 
 
-For exmaple, provide a dockerfile and run command
+For example, provide a dockerfile and run command
 
 ```
   apiserver:
@@ -45,6 +45,6 @@ The docker-compose by default will also spin up a prometheus and grafana instanc
 - Prometheus: http://localhost:9090/graph
 - Grafana: http://localhost:3000/d/2_KG1Va7z/mite-docker?orgId=1 
 
-Use default grafana admin creds
+Use default grafana admin creds (admin/admin)
 
 Note: May need to re-configure datasource on grafana to be prometheus

--- a/local/demo.py
+++ b/local/demo.py
@@ -1,6 +1,6 @@
 from mite.scenario import StopScenario
 from mite_http import mite_http
-
+import os
 
 def volume_model_factory(n):
     def vm(start, end):
@@ -13,8 +13,7 @@ def volume_model_factory(n):
 
 
 # Mock Server
-_API_URL = "http://apiserver:8000/"  # apiserver is for docker-compose. Change this to http://localhost:8000/ for local testing
-# TODO make http://apiserver:8000/ env var for controller and runners and default _API_URL to localhost
+_API_URL = os.environ.get("API_URL", "http://localhost:8000/")
 
 
 @mite_http
@@ -28,5 +27,5 @@ async def demo_req(ctx):
 
 def scenario():
     return [
-        ["local.demo:demo_req", None, volume_model_factory(10)],
+        ["local.demo:demo_req", None, volume_model_factory(2)],
     ]

--- a/local/demo.py
+++ b/local/demo.py
@@ -1,6 +1,8 @@
+import os
+
 from mite.scenario import StopScenario
 from mite_http import mite_http
-import os
+
 
 def volume_model_factory(n):
     def vm(start, end):

--- a/local/run_mite.sh
+++ b/local/run_mite.sh
@@ -8,8 +8,13 @@
 docker-compose -f docker_compose_monitoring.yml up -d
 
 # Run mite stack w/o controller
-mite runner --controller-socket=tcp://0.0.0.0:14301 --message-socket=tcp://0.0.0.0:14302 &
+mite runner --controller-socket=tcp://127.0.0.1:14301 --message-socket=tcp://127.0.0.1:14302 &
 mite duplicator --message-socket=tcp://0.0.0.0:14302 tcp://0.0.0.0:14303 &
-mite stats --stats-in-socket=tcp://0.0.0.0:14303 --stats-out-socket=tcp://0.0.0.0:14305 --stats-include-processors=mite,mite_http &
-mite prometheus_exporter --stats-out-socket=tcp://0.0.0.0:14305 --web-address=10.10.10.75:9301 &
-# mite controller --controller-socket=tcp://0.0.0.0:14301 --message-socket=tcp://10.11.12.13:14302 local.demo:scenario &
+mite stats --stats-in-socket=tcp://127.0.0.1:14303 --stats-out-socket=tcp://0.0.0.0:14305 --stats-include-processors=mite,mite_http &
+mite prometheus_exporter --stats-out-socket=tcp://127.0.0.1:14305 --web-address=0.0.0.0:9301 &
+
+# Start a mock web server
+# python -m http.server 8000 &
+
+# Controller Command
+# mite controller --controller-socket=tcp://0.0.0.0:14301 --message-socket=tcp://127.0.0.1:14302 local.demo:scenario &

--- a/prometheus/prometheus_config_docker.yml
+++ b/prometheus/prometheus_config_docker.yml
@@ -4,4 +4,4 @@ global:
 scrape_configs:
   - job_name: 'mite'
     static_configs:
-      - targets: ['mite-prometheus_exporter-1:9301'] # this address must equal the mite prometheus_exporter --web-address arg
+      - targets: ['prometheus_exporter:9301'] # this address must equal the mite prometheus_exporter --web-address arg

--- a/prometheus/prometheus_config_template.yml
+++ b/prometheus/prometheus_config_template.yml
@@ -4,5 +4,5 @@ global:
 scrape_configs:
   - job_name: 'mite'
     static_configs:
-      - targets: ['127.0.0.1:9301']
+      - targets: ['host.docker.internal:9301']
 


### PR DESCRIPTION
Expanding on changes from https://github.com/sky-uk/mite/pull/230

 - Updated `README.md`, removed `pip install mite` command and working instructions
 - Use a mount for journeys in the docker image, so it doesn't need to be rebuilt on changes to tests
 - Use an environment variable within docker-compose and the demo scenario for the `API_URL`
 - Update the docker grafana dashboard config to working correctly
 - In the prometheus config for docker, changed the prometheus target from `mite-prometheus_exporter-1` to `prometheus_exporter` (The containers were named as `mite_prometheus_exporter_1` on my machine, [looks like a version thing?](https://stackoverflow.com/a/69519102))
 - In the prometheus config for local tests, changed the prometheus target from `127.0.0.1` to `host.docker.internal` and removed `network_mode: "host"` from `docker_compose_monitoring.yaml` as that network_mode only works in Linux. (And this was tested on a Mac™)
 - Lowered replicas for stats in `docker_compose.yml` and TPS for the demo scenario

## Example

From this branch run the following commands

### Full docker scenario
```bash
docker build -t mite .
docker-compose -f docker_compose.yml up
```

Go to [grafana](http://localhost:3000/d/2_KG1Va7z/mite-docker?orgId=1&refresh=10s)!

### Run locally with prometheus/grafana in docker

```bash
python3 -m venv ~/.virtualenvs/mite
source ~/.virtualenvs/mite/bin/activate
pip install -r requirements.txt

./local/run_mite.sh
python -m http.server 8000 &
mite controller --controller-socket=tcp://0.0.0.0:14301 --message-socket=tcp://127.0.0.1:14302 local.demo:scenario &
```
Go to [grafana](http://localhost:3000/d/2_KG1Va7z/mite-docker?orgId=1&refresh=10s)!


(To kill the mite processes run `pkill -f mite`)
