### PR TITLE
pinned version of werkzeug

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,4 +12,4 @@ pytest-cov
 pytest-httpbin
 pytest-httpserver
 sanic
-werkzeug>=2.0
+werkzeug==2.0.3


### PR DESCRIPTION
It looks like pinning the version of werkzeug to 2.0.3 may fix this issue we are seeing with 2.1.0