### PR TITLE
Allow `mite cat` to cat bytes (#241) 🐱

### DIFF
--- a/mite/cli/cat.py
+++ b/mite/cli/cat.py
@@ -21,7 +21,7 @@ def prettify_timestamps(d):
 
 
 def cat(opts):
-    with open(opts['MSGPACK_FILE_PATH'], 'rb') as file_in:
+    with open(opts["MSGPACK_FILE_PATH"], "rb") as file_in:
         unpacker = msgpack.Unpacker(
             file_in, use_list=False, raw=False, strict_map_key=False
         )

--- a/mite/cli/cat.py
+++ b/mite/cli/cat.py
@@ -7,6 +7,13 @@ import msgpack
 from mite.utils import pack_msg
 
 
+class BytesEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, bytes):
+            return obj.decode("utf-8")
+        return json.JSONEncoder.default(self, obj)
+
+
 def prettify_timestamps(d):
     for key in ("time", "start_time", "end_time"):
         if key in d:
@@ -21,7 +28,7 @@ def cat(opts):
         for row in unpacker:
             if opts["--prettify-timestamps"]:
                 prettify_timestamps(row)
-            json.dump(row, sys.stdout)
+            json.dump(row, sys.stdout, cls=BytesEncoder)
             sys.stdout.write("\n")
 
 

--- a/mite_http/__init__.py
+++ b/mite_http/__init__.py
@@ -81,7 +81,7 @@ class SessionPool:
                 first_byte_time=r.starttransfer_time,
                 total_time=r.total_time,
                 primary_ip=r.primary_ip,
-                method=r.request.method,
+                method=r.request.method.decode("utf-8"),
                 **session_wrapper.additional_metrics,
             )
 

--- a/mite_http/__init__.py
+++ b/mite_http/__init__.py
@@ -81,7 +81,7 @@ class SessionPool:
                 first_byte_time=r.starttransfer_time,
                 total_time=r.total_time,
                 primary_ip=r.primary_ip,
-                method=r.request.method.decode("utf-8"),
+                method=r.request.method,
                 **session_wrapper.additional_metrics,
             )
 


### PR DESCRIPTION
I'm not sure if it's related to using the new acurl, but.. the http method was getting sent with the type bytes, causing `mite cat` to fail, e.g.

```
$ mite cat collector_data/current
{"start_time": 1657611774, "effective_url": "http://localhost:9898/", "response_code": 200, "dns_time": 6e-06, "connect_time": 6e-06, "tls_time": 0.0, "transfer_start_time": 1.4e-05, "first_byte_time": 0.000248, "total_time": 0.000252, "primary_ip": "127.0.0.1", "method": Traceback (most recent call last):
  File "/Users/rli14/mite/mite_env/bin/mite", line 33, in <module>
    sys.exit(load_entry_point('mite', 'console_scripts', 'mite')())
  File "/Users/rli14/mite/mite/__main__.py", line 352, in main
    cat(opts)
  File "/Users/rli14/mite/mite/cli/cat.py", line 24, in cat
    json.dump(row, sys.stdout)
  ...
TypeError: Object of type bytes is not JSON serializable
```

This PR fixes `mite cat` to allow it to handle byte values.