### PR TITLE
Correctly check acurl version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
               ACURL_CHANGED=true
 
               LATEST_ACURL_VERSION=$(curl -s https://pypi.org/pypi/acurl/json | jq -r '.info .version')
-              if [[ -n $(grep "version = $LATEST_ACURL_VERSION" acurl/setup.cfg) ]]; then
+              if [[ -n $(grep "version = $LATEST_ACURL_VERSION$" acurl/setup.cfg) ]]; then
                 echo "Acurl has changed, but the version of acurl hasn't changed"
                 exit 1
               fi


### PR DESCRIPTION
When grep'ing for the acurl version, make sure we check the version number AND the end of the line.

For cases when the current version number is `1.0` but the updated version is `1.0.1` a match would occur, causing a failure, even when the version number has changed.