### PR TITLE
Add git identity for circleci git tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,8 @@ jobs:
       - run:
           name: tag github version
           command: |
+            git config user.email "mite@noreply.github.com"
+            git config user.name "CircleCI"
             pip3 install docopt GitPython packaging
             python3 cd-scripts/cdRelease.py patch
 

--- a/acurl/setup.cfg
+++ b/acurl/setup.cfg
@@ -17,7 +17,7 @@ maintainer = Sky Identity NFT team
 maintainer_email = matthew.ellis@sky.uk
 license = MIT
 url = https://github.com/sky-uk/mite/tree/master/acurl
-version = 1.0.1
+version = 1.0.2
 
 [options]
 install_requires =


### PR DESCRIPTION
Even though it worked testing it on my own repo, for some reason it's complaining it can't tag with the error:

```
*** git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git tag -m Automatic version tag v0.0.1 v0.0.1 HEAD
  stderr: 'Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'circleci@3c648b6445d6.(none)')'
```

Adding the following lines _should_ fix it

```bash
git config user.email "mite@noreply.github.com"
git config user.name "CircleCI"
```

---

Also added a version change for acurl to test the build/push process for that.