### PR TITLE
Better versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,36 +18,37 @@ workflows:
   mite:
     jobs:
       - check-acurl-version
-      - build-and-test-38:
-          requires:
-            - check-acurl-version
-      - build-and-test-39:
-          requires:
-            - check-acurl-version
-      - build-and-test-310:
-          requires:
-            - check-acurl-version
+      # - build-and-test-38:
+      #     requires:
+      #       - check-acurl-version
+      # - build-and-test-39:
+      #     requires:
+      #       - check-acurl-version
+      # - build-and-test-310:
+      #     requires:
+      #       - check-acurl-version
       - tag:
           requires:
-            - build-and-test-38
-            - build-and-test-39
-            - build-and-test-310
+            # - build-and-test-38
+            # - build-and-test-39
+            # - build-and-test-310
             - check-acurl-version
-          filters:
-            branches:
-              only: master
-      - linux-wheels:
-          requires:
-            - tag
-          filters:
-            branches:
-              only: master
-      - osx-wheels:
-          requires:
-            - tag
-          filters:
-            branches:
-              only: master
+      - test-env-vars
+      #     filters:
+      #       branches:
+      #         only: master
+      # - linux-wheels:
+      #     requires:
+      #       - tag
+      #     filters:
+      #       branches:
+      #         only: master
+      # - osx-wheels:
+      #     requires:
+      #       - tag
+      #     filters:
+      #       branches:
+      #         only: master
 
 
 jobs:
@@ -156,6 +157,25 @@ jobs:
           root: /tmp/workspace
           paths:
             - env_vars
+
+
+  test-env-vars:
+    docker:
+      - image: cimg/python:3.10
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: test env vars.
+          command: |
+            source /tmp/workspace/env_vars
+
+            if [ "$VERSION_INCREMENT" = false ]; then
+              echo "Mite version not incremented, not building"
+            else
+              echo "Building mite"
+            fi
 
 
   linux-wheels:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,10 +87,11 @@ jobs:
       - run:
           name: tag github version
           command: |
-            if [[ -z "$CIRCLE_PR_NUMBER" ]]; then
-              echo $CIRCLE_PR_NUMBER
+            if [[ -z "$CIRCLE_PULL_REQUEST" ]]; then
+              PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | sed s*https://github.com/sky-uk/mite/pull/**)
+              echo $PR_NUMBER
             else
-              echo "Can not find CIRCLE_PR_NUMBER"
+              echo "Can not find CIRCLE_PULL_REQUEST"
             fi
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,6 @@ jobs:
           paths:
             - env_vars
 
-
   build-and-test-38:
     docker:
       - image: cimg/python:3.8
@@ -139,6 +138,8 @@ jobs:
           fingerprints:
             - "fc:39:a2:b8:32:23:52:a5:fe:45:b6:9b:12:e7:30:2a"
       - checkout
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           name: tag github version
           command: |
@@ -151,6 +152,11 @@ jobs:
             else
               python3 cd-scripts/cdRelease.py patch
             fi
+      - persist_to_workspace:
+          root: /tmp/workspace
+          paths:
+            - env_vars
+
 
   linux-wheels:
     # we only need to build the 'mite' wheels on one platform
@@ -170,8 +176,13 @@ jobs:
           name: Build the Linux wheels.
           command: |
             source /tmp/workspace/env_vars
-            pip3 install --user cibuildwheel==2.8.1 build Cython twine
-            python3 -m build --outdir ./wheelhouse
+
+            if [ "$VERSION_INCREMENT" = false ]; then
+              echo "Mite version not incremented, not building"
+            else
+              pip3 install --user cibuildwheel==2.8.1 build Cython twine
+              python3 -m build --outdir ./wheelhouse
+            fi
 
             if [ "$ACURL_CHANGED" = true ]; then
               cd acurl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,38 +17,37 @@ orbs:
 workflows:
   mite:
     jobs:
-      - test_circle_pr
-      # - check-acurl-version
-      # - build-and-test-38:
-      #     requires:
-      #       - check-acurl-version
-      # - build-and-test-39:
-      #     requires:
-      #       - check-acurl-version
-      # - build-and-test-310:
-      #     requires:
-      #       - check-acurl-version
-      # - tag:
-      #     requires:
-      #       - build-and-test-38
-      #       - build-and-test-39
-      #       - build-and-test-310
-      #       - check-acurl-version
-      #     filters:
-      #       branches:
-      #         only: master
-      # - linux-wheels:
-      #     requires:
-      #       - tag
-      #     filters:
-      #       branches:
-      #         only: master
-      # - osx-wheels:
-      #     requires:
-      #       - tag
-      #     filters:
-      #       branches:
-      #         only: master
+      - check-acurl-version
+      - build-and-test-38:
+          requires:
+            - check-acurl-version
+      - build-and-test-39:
+          requires:
+            - check-acurl-version
+      - build-and-test-310:
+          requires:
+            - check-acurl-version
+      - tag:
+          requires:
+            - build-and-test-38
+            - build-and-test-39
+            - build-and-test-310
+            - check-acurl-version
+          filters:
+            branches:
+              only: master
+      - linux-wheels:
+          requires:
+            - tag
+          filters:
+            branches:
+              only: master
+      - osx-wheels:
+          requires:
+            - tag
+          filters:
+            branches:
+              only: master
 
 
 jobs:
@@ -78,21 +77,6 @@ jobs:
           root: /tmp/workspace
           paths:
             - env_vars
-
-  test_circle_pr:
-    docker:
-      - image: cimg/python:3.10
-    steps:
-      - checkout
-      - run:
-          name: tag github version
-          command: |
-            if [[ -z "$CIRCLE_PULL_REQUEST" ]]; then
-              PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | sed s*https://github.com/sky-uk/mite/pull/**)
-              echo $PR_NUMBER
-            else
-              echo "Can not find CIRCLE_PULL_REQUEST"
-            fi
 
 
   build-and-test-38:
@@ -161,8 +145,9 @@ jobs:
             git config user.email "mite@noreply.github.com"
             git config user.name "CircleCI"
             pip3 install docopt GitPython packaging requests
-            if [[ -z "$CIRCLE_PR_NUMBER" ]]; then
-              python3 cd-scripts/cdRelease.py --pr_number=$CIRCLE_PR_NUMBER
+            if [[ -v CIRCLE_PULL_REQUEST ]]; then
+              PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | sed s*https://github.com/sky-uk/mite/pull/**)
+              python3 cd-scripts/cdRelease.py --pr_number=$PR_NUMBER
             else
               python3 cd-scripts/cdRelease.py patch
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,10 @@ workflows:
             # - build-and-test-39
             # - build-and-test-310
             - check-acurl-version
-      - test-env-vars
+      - test-env-vars:
+          requires:
+            - tag
+
       #     filters:
       #       branches:
       #         only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,40 +18,35 @@ workflows:
   mite:
     jobs:
       - check-acurl-version
-      # - build-and-test-38:
-      #     requires:
-      #       - check-acurl-version
-      # - build-and-test-39:
-      #     requires:
-      #       - check-acurl-version
-      # - build-and-test-310:
-      #     requires:
-      #       - check-acurl-version
+      - build-and-test-38:
+          requires:
+            - check-acurl-version
+      - build-and-test-39:
+          requires:
+            - check-acurl-version
+      - build-and-test-310:
+          requires:
+            - check-acurl-version
       - tag:
           requires:
-            # - build-and-test-38
-            # - build-and-test-39
-            # - build-and-test-310
-            - check-acurl-version
-      - test-env-vars:
+            - build-and-test-38
+            - build-and-test-39
+            - build-and-test-310
+          filters:
+            branches:
+              only: master
+      - linux-wheels:
           requires:
             - tag
-
-      #     filters:
-      #       branches:
-      #         only: master
-      # - linux-wheels:
-      #     requires:
-      #       - tag
-      #     filters:
-      #       branches:
-      #         only: master
-      # - osx-wheels:
-      #     requires:
-      #       - tag
-      #     filters:
-      #       branches:
-      #         only: master
+          filters:
+            branches:
+              only: master
+      - osx-wheels:
+          requires:
+            - tag
+          filters:
+            branches:
+              only: master
 
 
 jobs:
@@ -160,25 +155,6 @@ jobs:
           root: /tmp/workspace
           paths:
             - env_vars
-
-
-  test-env-vars:
-    docker:
-      - image: cimg/python:3.10
-    steps:
-      - checkout
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          name: test env vars.
-          command: |
-            source /tmp/workspace/env_vars
-
-            if [ "$VERSION_INCREMENT" = false ]; then
-              echo "Mite version not incremented, not building"
-            else
-              echo "Building mite"
-            fi
 
 
   linux-wheels:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,37 +17,38 @@ orbs:
 workflows:
   mite:
     jobs:
-      - check-acurl-version
-      - build-and-test-38:
-          requires:
-            - check-acurl-version
-      - build-and-test-39:
-          requires:
-            - check-acurl-version
-      - build-and-test-310:
-          requires:
-            - check-acurl-version
-      - tag:
-          requires:
-            - build-and-test-38
-            - build-and-test-39
-            - build-and-test-310
-            - check-acurl-version
-          filters:
-            branches:
-              only: master
-      - linux-wheels:
-          requires:
-            - tag
-          filters:
-            branches:
-              only: master
-      - osx-wheels:
-          requires:
-            - tag
-          filters:
-            branches:
-              only: master
+      - test_circle_pr
+      # - check-acurl-version
+      # - build-and-test-38:
+      #     requires:
+      #       - check-acurl-version
+      # - build-and-test-39:
+      #     requires:
+      #       - check-acurl-version
+      # - build-and-test-310:
+      #     requires:
+      #       - check-acurl-version
+      # - tag:
+      #     requires:
+      #       - build-and-test-38
+      #       - build-and-test-39
+      #       - build-and-test-310
+      #       - check-acurl-version
+      #     filters:
+      #       branches:
+      #         only: master
+      # - linux-wheels:
+      #     requires:
+      #       - tag
+      #     filters:
+      #       branches:
+      #         only: master
+      # - osx-wheels:
+      #     requires:
+      #       - tag
+      #     filters:
+      #       branches:
+      #         only: master
 
 
 jobs:
@@ -77,6 +78,21 @@ jobs:
           root: /tmp/workspace
           paths:
             - env_vars
+
+  test_circle_pr:
+    docker:
+      - image: cimg/python:3.10
+    steps:
+      - checkout
+      - run:
+          name: tag github version
+          command: |
+            if [[ -z "$CIRCLE_PR_NUMBER" ]]; then
+              echo $CIRCLE_PR_NUMBER
+            else
+              echo "Can not find CIRCLE_PR_NUMBER"
+            fi
+
 
   build-and-test-38:
     docker:
@@ -143,8 +159,12 @@ jobs:
           command: |
             git config user.email "mite@noreply.github.com"
             git config user.name "CircleCI"
-            pip3 install docopt GitPython packaging
-            python3 cd-scripts/cdRelease.py patch
+            pip3 install docopt GitPython packaging requests
+            if [[ -z "$CIRCLE_PR_NUMBER" ]]; then
+              python3 cd-scripts/cdRelease.py --pr_number=$CIRCLE_PR_NUMBER
+            else
+              python3 cd-scripts/cdRelease.py patch
+            fi
 
   linux-wheels:
     # we only need to build the 'mite' wheels on one platform

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+
+#### What is the change?
+
+#### Does this change require a version increment:
+
+- [ ] Major
+- [ ] Minor
+- [x] Patch

--- a/cd-scripts/cdRelease.py
+++ b/cd-scripts/cdRelease.py
@@ -132,9 +132,7 @@ def main():
     else:
         new_tag = increment_version_manually(current_latest_version, opts)
 
-    print(new_tag)
-
-    # create_and_push_tag(repo, new_tag)
+    create_and_push_tag(repo, new_tag)
 
     sys.exit(0)
 

--- a/cd-scripts/cdRelease.py
+++ b/cd-scripts/cdRelease.py
@@ -82,7 +82,7 @@ def parse_pr(opts):
     )
     pr_message = resp.json()["body"]
 
-    matches = re.findall(r"- \[x\] (\w+)(?:$|\n)", pr_message, re.IGNORECASE)
+    matches = re.findall(r"- \[x\] (\w+)(?:$|[\n\r])", pr_message, re.IGNORECASE)
 
     # Return a lowercase list, in case the user has changed the case during
     # the creation of their pull request

--- a/cd-scripts/cdRelease.py
+++ b/cd-scripts/cdRelease.py
@@ -39,6 +39,10 @@ def increment_version_from_pr(clv, version_parts_to_increment):
         patch = 0
     elif "patch" in version_parts_to_increment:
         patch += 1
+    else:
+        raise ValueError(
+            f"Does not contain a valid specification of a version to increment: {version_parts_to_increment}"
+        )
 
     return f"v{major}.{minor}.{patch}"
 
@@ -82,11 +86,13 @@ def parse_pr(opts):
     )
     pr_message = resp.json()["body"]
 
-    matches = re.findall(r"- \[x\] (\w+)(?:$|[\n\r])", pr_message, re.IGNORECASE)
+    matches = re.findall(
+        r"^- \[x\] (major|minor|patch)\r$", pr_message, re.IGNORECASE | re.MULTILINE
+    )
 
     # Return a lowercase list, in case the user has changed the case during
     # the creation of their pull request
-    return [x.lower() for x in matches]
+    return [m.lower() for m in matches if m.lower() in ("major", "minor", "patch")]
 
 
 def main():
@@ -126,7 +132,9 @@ def main():
     else:
         new_tag = increment_version_manually(current_latest_version, opts)
 
-    create_and_push_tag(repo, new_tag)
+    print(new_tag)
+
+    # create_and_push_tag(repo, new_tag)
 
     sys.exit(0)
 

--- a/cd-scripts/cdRelease.py
+++ b/cd-scripts/cdRelease.py
@@ -115,6 +115,11 @@ def main():
 
     if opts["--pr_number"]:
         version_parts_to_increment = parse_pr(opts)
+        if not version_parts_to_increment:
+            logger.info("No release")
+            with open("/tmp/workspace/env_vars", "a") as f:
+                f.write("export VERSION_INCREMENT=false")
+            sys.exit(0)
         new_tag = increment_version_from_pr(
             current_latest_version, version_parts_to_increment
         )

--- a/cd-scripts/cdRelease.py
+++ b/cd-scripts/cdRelease.py
@@ -1,9 +1,10 @@
 """cdRelease
 
 Usage:
-    cdRelease.py [options] patch
-    cdRelease.py [options] minor
     cdRelease.py [options] major
+    cdRelease.py [options] minor
+    cdRelease.py [options] patch
+    cdRelease.py [options] [--pr_number=<pr_number>]
 
     cdRelease.py (-h | --help)
 
@@ -13,16 +14,36 @@ Options:
 """
 
 import logging
+import re
 import sys
 
 import docopt
 import git
+import requests
 from packaging.version import parse
 
 logger = logging.getLogger("cdRelease")
 
 
-def increment_version(clv, opts):
+def increment_version_from_pr(clv, version_parts_to_increment):
+    major = clv.major
+    minor = clv.minor
+    patch = clv.micro
+
+    if "major" in version_parts_to_increment:
+        major += 1
+        minor = 0
+        patch = 0
+    elif "minor" in version_parts_to_increment:
+        minor += 1
+        patch = 0
+    elif "patch" in version_parts_to_increment:
+        patch += 1
+
+    return f"v{major}.{minor}.{patch}"
+
+
+def increment_version_manually(clv, opts):
     if opts["major"]:
         major = clv.major + 1
         minor = 0
@@ -55,6 +76,19 @@ def create_and_push_tag(repo, tag):
         sys.exit(1)
 
 
+def parse_pr(opts):
+    resp = requests.get(
+        f"https://api.github.com/repos/sky-uk/mite/pulls/{opts['--pr_number']}"
+    )
+    pr_message = resp.json()["body"]
+
+    matches = re.findall(r"- \[x\] (\w+)(?:$|\n)", pr_message, re.IGNORECASE)
+
+    # Return a lowercase list, in case the user has changed the case during
+    # the creation of their pull request
+    return [x.lower() for x in matches]
+
+
 def main():
     opts = docopt.docopt(__doc__)
     logging.basicConfig(
@@ -78,7 +112,14 @@ def main():
         latest_tag = "v0.0.0"
 
     current_latest_version = parse(latest_tag)
-    new_tag = increment_version(current_latest_version, opts)
+
+    if opts["--pr_number"]:
+        version_parts_to_increment = parse_pr(opts)
+        new_tag = increment_version_from_pr(
+            current_latest_version, version_parts_to_increment
+        )
+    else:
+        new_tag = increment_version_manually(current_latest_version, opts)
 
     create_and_push_tag(repo, new_tag)
 


### PR DESCRIPTION
#### What is the change?

Introducing a basic PR template to include versioning options. Allowing you to choose which version segment you increment.

Modified the `cdRelease.py` script to get the version segment to increment from the PR.

With this PR, I've chosen to increment `Major' as the PyPi versions are muddied due to taking over the namespace from an old project (and a little from myself by not pushing test packages to test.pypi.org 😊).

The used versions are:

```
0.1.16 | August 10th, 2022 06:24
0.1.15 | August 8th, 2022 19:41
0.1.10 | August 4th, 2022 16:12
0.1.9 | August 4th, 2022 14:59
0.1.7 | August 4th, 2022 14:44
0.1.6 | August 4th, 2022 14:15
0.1 | March 21st, 2022 12:03
0.0.8 | November 22nd, 2018 11:28
0.0.7 | July 29th, 2018 18:09
0.0.6 | July 29th, 2018 18:09
0.0.5 | July 29th, 2018 17:47
0.0.4 | July 29th, 2018 16:11
0.0.3 | July 29th, 2018 15:20
0.0.2 | July 29th, 2018 15:17
0.0.1 | July 29th, 2018 15:14
```

Which is why [this CircleCI job](https://circleci.com/gh/sky-uk/mite/173) failed when trying to push the `mite-0.0.1-py3-none-any.whl` file to PyPi.

Jumping to version 1.0.0 will get us around this issue.

#### Does this change require a version increment:

- [x] Major
- [ ] Minor
- [ ] Patch
