### PR TITLE
Correctly get PR body when ran from master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,12 +145,7 @@ jobs:
             git config user.email "mite@noreply.github.com"
             git config user.name "CircleCI"
             pip3 install docopt GitPython packaging requests
-            if [[ -v CIRCLE_PULL_REQUEST ]]; then
-              PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | sed s*https://github.com/sky-uk/mite/pull/**)
-              python3 cd-scripts/cdRelease.py --pr_number=$PR_NUMBER
-            else
-              python3 cd-scripts/cdRelease.py patch
-            fi
+            python3 cd-scripts/cdRelease.py
       - persist_to_workspace:
           root: /tmp/workspace
           paths:

--- a/cd-scripts/cdRelease.py
+++ b/cd-scripts/cdRelease.py
@@ -1,15 +1,16 @@
 """cdRelease
 
 Usage:
-    cdRelease.py [options] major
-    cdRelease.py [options] minor
-    cdRelease.py [options] patch
+    cdRelease.py [options] [--patch|--minor|--major]
     cdRelease.py [options] [--pr_number=<pr_number>]
 
     cdRelease.py (-h | --help)
 
 Options:
     -h --help       Show this screen
+    --patch         Increment patch version segment
+    --minor         Increment minor version segment
+    --major         Increment major version segment
 
 """
 
@@ -48,15 +49,15 @@ def increment_version_from_pr(clv, version_parts_to_increment):
 
 
 def increment_version_manually(clv, opts):
-    if opts["major"]:
+    if opts["--major"]:
         major = clv.major + 1
         minor = 0
         patch = 0
-    elif opts["minor"]:
+    elif opts["--minor"]:
         major = clv.major
         minor = clv.minor + 1
         patch = 0
-    elif opts["patch"]:
+    elif opts["--patch"]:
         major = clv.major
         minor = clv.minor
         patch = clv.micro + 1
@@ -80,9 +81,9 @@ def create_and_push_tag(repo, tag):
         sys.exit(1)
 
 
-def parse_pr(opts):
+def parse_pr(pr_number):
     resp = requests.get(
-        f"https://api.github.com/repos/sky-uk/mite/pulls/{opts['--pr_number']}"
+        f"https://api.github.com/repos/sky-uk/mite/pulls/{pr_number}"
     )
     pr_message = resp.json()["body"]
 
@@ -104,13 +105,13 @@ def main():
 
     repo = git.Repo(".")
 
-    if current_tag := next(
-        (tag for tag in repo.tags if tag.commit == repo.head.commit), None
-    ):
-        logger.error(
-            f"Commit hash '{repo.head.commit}' Already has a tag '{current_tag}'"
-        )
-        sys.exit(1)
+    # if current_tag := next(
+    #     (tag for tag in repo.tags if tag.commit == repo.head.commit), None
+    # ):
+    #     logger.error(
+    #         f"Commit hash '{repo.head.commit}' Already has a tag '{current_tag}'"
+    #     )
+    #     sys.exit(1)
 
     try:
         latest_tag = repo.git.describe(["--abbrev=0", "--tags"])
@@ -119,8 +120,23 @@ def main():
 
     current_latest_version = parse(latest_tag)
 
-    if opts["--pr_number"]:
-        version_parts_to_increment = parse_pr(opts)
+    
+    if any([
+        opts["--major"],
+        opts["--minor"],
+        opts["--patch"],
+    ]):
+        # Get version increment from command line arg.
+        new_tag = increment_version_manually(current_latest_version, opts)
+    else:
+        if opts["--pr_number"]:
+            # Get version increment from value set in PR message body
+            version_parts_to_increment = parse_pr(opts["--pr_number"])
+        else:
+            commit_message = repo.git.log("--format=%B", n=1)
+            matches = re.findall(r"^.*\(#(\d+)\)$", commit_message, re.MULTILINE)
+            version_parts_to_increment = parse_pr(matches[0])
+
         if not version_parts_to_increment:
             logger.info("No release")
             with open("/tmp/workspace/env_vars", "a") as f:
@@ -129,10 +145,12 @@ def main():
         new_tag = increment_version_from_pr(
             current_latest_version, version_parts_to_increment
         )
-    else:
-        new_tag = increment_version_manually(current_latest_version, opts)
 
-    create_and_push_tag(repo, new_tag)
+    print(new_tag)
+
+    sys.exit(0)
+
+    # create_and_push_tag(repo, new_tag)
 
     sys.exit(0)
 

--- a/cd-scripts/cdRelease.py
+++ b/cd-scripts/cdRelease.py
@@ -82,9 +82,7 @@ def create_and_push_tag(repo, tag):
 
 
 def parse_pr(pr_number):
-    resp = requests.get(
-        f"https://api.github.com/repos/sky-uk/mite/pulls/{pr_number}"
-    )
+    resp = requests.get(f"https://api.github.com/repos/sky-uk/mite/pulls/{pr_number}")
     pr_message = resp.json()["body"]
 
     matches = re.findall(
@@ -120,17 +118,12 @@ def main():
 
     current_latest_version = parse(latest_tag)
 
-    
-    if any([
-        opts["--major"],
-        opts["--minor"],
-        opts["--patch"],
-    ]):
+    if any([opts["--major"], opts["--minor"], opts["--patch"]]):
         # Get version increment from command line arg.
         new_tag = increment_version_manually(current_latest_version, opts)
     else:
+        # Get version increment from value set in PR message body
         if opts["--pr_number"]:
-            # Get version increment from value set in PR message body
             version_parts_to_increment = parse_pr(opts["--pr_number"])
         else:
             commit_message = repo.git.log("--format=%B", n=1)

--- a/cd-scripts/cdRelease.py
+++ b/cd-scripts/cdRelease.py
@@ -105,13 +105,13 @@ def main():
 
     repo = git.Repo(".")
 
-    # if current_tag := next(
-    #     (tag for tag in repo.tags if tag.commit == repo.head.commit), None
-    # ):
-    #     logger.error(
-    #         f"Commit hash '{repo.head.commit}' Already has a tag '{current_tag}'"
-    #     )
-    #     sys.exit(1)
+    if current_tag := next(
+        (tag for tag in repo.tags if tag.commit == repo.head.commit), None
+    ):
+        logger.error(
+            f"Commit hash '{repo.head.commit}' Already has a tag '{current_tag}'"
+        )
+        sys.exit(1)
 
     try:
         latest_tag = repo.git.describe(["--abbrev=0", "--tags"])
@@ -146,11 +146,7 @@ def main():
             current_latest_version, version_parts_to_increment
         )
 
-    print(new_tag)
-
-    sys.exit(0)
-
-    # create_and_push_tag(repo, new_tag)
+    create_and_push_tag(repo, new_tag)
 
     sys.exit(0)
 


### PR DESCRIPTION
#### What is the change?

From https://github.com/sky-uk/mite/pull/246 I made the assumption that `CIRCLE_PULL_REQUEST` would be available during the master build. Unfortunately that's not the case and instead we need to get the PR info from `git log --format=%B -n 1`

Hopefully third time is the charm and it works this time 😮‍💨 

#### Does this change require a version increment:

- [x] Major
- [ ] Minor
- [ ] Patch
