### PR TITLE
fix mite selenium _extract_entries log string

### DIFF
--- a/mite_selenium/__init__.py
+++ b/mite_selenium/__init__.py
@@ -138,7 +138,7 @@ class _SeleniumWrapper:
         if len(entries) == expected:
             return entries[:expected]
         logger.error(
-            f"Performance entries did not return the expected count: expected 1 - actual {len(entries)}"
+            f"Performance entries did not return the expected count: expected {expected} - actual {len(entries)}"
         )
         return
 


### PR DESCRIPTION
#### What is the change?
The error log string in the _extract_entries function contains a hard corded expected value of 1. The function is called in line 96 (_timings) with an expected value of 1, but it is also used in line 123 (_paint_timings) with an expected value of 2. The expected values difference can help debugging but the string would always log 1, causing confusion on which call actually failed.
#### Does this change require a version increment:
Not really.
- [ ] Major
- [x] Minor
- [ ] Patch
