### PR TITLE
Build aarch64 linux wheels for acurl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
             if [ "$ACURL_CHANGED" = true ]; then
               cd acurl
               python3 -m build --sdist --outdir ../wheelhouse
-              cibuildwheel --output-dir ../wheelhouse
+              cibuildwheel --output-dir ../wheelhouse --archs x86_64,aarch64
             fi
       - run:
           name: init .pypirc

--- a/acurl/setup.cfg
+++ b/acurl/setup.cfg
@@ -17,7 +17,7 @@ maintainer = Sky Identity NFT team
 maintainer_email = matthew.ellis@sky.uk
 license = MIT
 url = https://github.com/sky-uk/mite/tree/master/acurl
-version = 1.0.2
+version = 1.0.3
 
 [options]
 install_requires =


### PR DESCRIPTION
#### What is the change?

Currently the CircleCi job only build x86_64 linux wheels and x86_64/arm64 mac wheels. This change will add the build of aarch64 wheels for linux.

The use case for this is using a linux docker image on an M1 mac (without having to use a x86_64 image and the performance degradation that involves). Or a native linux os on aarch64 architecture.

#### Does this change require a version increment:

- [ ] Major
- [ ] Minor
- [ ] Patch
