### PR TITLE
Fix mite_browser calls the http methods

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,12 +174,13 @@ jobs:
             if [ "$VERSION_INCREMENT" = false ]; then
               echo "Mite version not incremented, not building"
             else
-              pip3 install --user cibuildwheel==2.8.1 build Cython twine
+              pip3 install --user cibuildwheel==2.8.1 build twine
               python3 -m build --outdir ./wheelhouse
             fi
 
             if [ "$ACURL_CHANGED" = true ]; then
               cd acurl
+              pip3 install --user cibuildwheel==2.8.1 build Cython twine
               python3 -m build --sdist --outdir ../wheelhouse
               cibuildwheel --output-dir ../wheelhouse
             fi

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 twine~=1.13.0
 keyring~=19.0.2
 tox~=3.14.2
-pre-commit~=1.17.0
+pre-commit~=2.20.0
 flake8~=3.7.8
 black~=22.3.0
 coverage~=5.1

--- a/mite_browser/__init__.py
+++ b/mite_browser/__init__.py
@@ -88,7 +88,8 @@ class Browser:
         """Perform a request and return a page object"""
         # Wrap everything in page object
         embedded_res = kwargs.pop("embedded_res", self._embedded_res)
-        resp = await self._session.request(method, url, *args, **kwargs)
+        method_func = getattr(self._session, method.lower())
+        resp = await method_func(url, *args, **kwargs)
         page = Page(resp, self)
         if embedded_res:
             async with self._ctx.transaction(


### PR DESCRIPTION
#### What is the change?

As we now use "acurl_ng" by default, the Session object doesn't have a `request` method, so mite_browser was broken and you would get the following error:

```
AttributeError: AttributeError: 'acurl.Session' object has no attribute 'request'
```

This PR finds the methods function and calls that instead.

#### Does this change require a version increment:

- [ ] Major
- [ ] Minor
- [x] Patch
