### PR TITLE
Change selenium-wire required version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ finagle =
     thrift
 selenium =
     selenium
-selenium_wire = selenium-wire>=4.3.0
+selenium_wire = selenium-wire==4.6.5
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
#### What is the change?
Change selenium-wire required version from >=4.3.0 to ==4.6.5.
We did not have a "successful" (was green but not journey runs) idris-signin test since the 26th of September 2022 because of `Controller job died prematurely or waiting timed out`. Running the test locally raises `ImportError: cannot import name 'EdgeOptions' from 'selenium.webdriver'`, which can also be observed on the pods log (runners only). Strangely enough, the pods status show "Completed" rather that "Error"...
On the same date we started to observe the issue, was released the selenium-wire version 5.0.0. Testing with the previous release (4.6.5) seems to fix the tests.
#### Does this change require a version increment:

- [ ] Major
- [ ] Minor
- [x] Patch
