### PR TITLE
Fix twine path for uploading Linux wheels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,7 @@ jobs:
             echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
       - run:
           name: upload packages to pypi
-          command: twine upload wheelhouse/*
+          command: /root/.local/bin/twine upload wheelhouse/*
       - store_artifacts:
           path: wheelhouse/
 


### PR DESCRIPTION
#### What is the change?

Using the `python:3.11.2` image, we now need to specify the full path for twine.

#### Does this change require a version increment:

- [ ] Major
- [ ] Minor
- [ ] Patch
