### PR TITLE
Fix `mite scenario` never completing when scenario is finished

### DIFF
--- a/acurl/MANIFEST.in
+++ b/acurl/MANIFEST.in
@@ -1,2 +1,3 @@
 include src/*.c
+include src/*.pyx
 include src/acurl_wrappers.h

--- a/acurl/MANIFEST.in
+++ b/acurl/MANIFEST.in
@@ -1,3 +1,4 @@
 include src/*.c
 include src/*.pyx
+include src/*.pxd
 include src/acurl_wrappers.h

--- a/acurl/setup.cfg
+++ b/acurl/setup.cfg
@@ -17,7 +17,7 @@ maintainer = Sky Identity NFT team
 maintainer_email = matthew.ellis@sky.uk
 license = MIT
 url = https://github.com/sky-uk/mite/tree/master/acurl
-version = 1.0.4
+version = 1.0.5
 
 [options]
 install_requires =

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -150,7 +150,7 @@ def test_scenarios(test_name, opts, scenarios, config_manager):
         initial_snapshot = tracemalloc.take_snapshot()
         tasks.append(loop.create_task(mem_snapshot(initial_snapshot)))
 
-    loop.run_until_complete(asyncio.gather(*tasks))
+    loop.run_until_complete(asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED))
 
     # Run one last report before exiting
     controller.report(receiver.recieve)


### PR DESCRIPTION
#### What is the change?

A previous PR: https://github.com/sky-uk/mite/pull/254 Introduced a bug that will never allow a scenario test to finish running.

This PR fixed that by replacing the asyncio `gather` call with a `wait` call with the `return_when=asyncio.FIRST_COMPLETED` parameter.


This was tested by creating the following scenario and running the command:

```
$ mite scenario test a:scenario --log-level=WARN
Stopping Scenario
```

```python
import asyncio

from mite.scenario import StopVolumeModel


def volume_model_factory(n):
    def vm(start, end):
        if start > 1:
            print("Stopping Scenario")
            raise StopVolumeModel
        return n

    vm.__name__ = f"volume model {n}"
    return vm


def scenario():
    return [
        ["a:j", None, volume_model_factory(1)],
    ]


async def j(ctx):
    await asyncio.sleep(1)
```

Also added `*.pyx` and `*.pxd` files to `acurl/MANIFEST.in`. These files are required for building the acurl package, but were previously left out (forgotton :D)

#### Does this change require a version increment:

- [ ] Major
- [ ] Minor
- [x] Patch
