### PR TITLE
Fix shared browser options between wire and non wire journeys

### DIFF
--- a/mite_selenium/__init__.py
+++ b/mite_selenium/__init__.py
@@ -13,6 +13,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 from mite.exceptions import MiteError
 from mite.utils import spec_import
+from copy import deepcopy
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +36,7 @@ class _SeleniumWrapper:
         self._file_detector = self._spec_import_if_not_none("webdriver_file_detector")
         self._proxy = self._spec_import_if_not_none("webdriver_proxy")
         self._browser_profile = self._spec_import_if_not_none("webdriver_browser_profile")
-        self._options = self._spec_import_if_not_none("webdriver_options")
+        self._options = deepcopy(self._spec_import_if_not_none("webdriver_options"))
 
         # Required param
         self._capabilities = self._context.config.get("webdriver_capabilities")

--- a/mite_selenium/__init__.py
+++ b/mite_selenium/__init__.py
@@ -3,6 +3,7 @@ import logging
 import socket
 import time
 from contextlib import asynccontextmanager
+from copy import deepcopy
 from functools import wraps
 
 from selenium.common.exceptions import TimeoutException
@@ -13,7 +14,6 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 from mite.exceptions import MiteError
 from mite.utils import spec_import
-from copy import deepcopy
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
#### What is the change?
On instanciation of a new webdriver, the _options attribute is set to a reference of a webdriver options object (e.g. selenium.webdriver.chrome.options.Options). This causes any modification of the options to be reflected on possibly all the running webdrivers, or at the very least, on the webdrivers created after modification of the options.
As an example, when a webdriver is created by seleniumwire, its options are somehow modified by seleniumwire to comprise the proxy address. This causes all webdrivers, or at least the ones created after the options modification, to use that proxy as well. 
#### Does this change require a version increment:

- [ ] Major
- [ ] Minor
- [x] Patch
