### PR TITLE
Update pyproject.toml

### DIFF
--- a/acurl/pyproject.toml
+++ b/acurl/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython"]
+requires = ["setuptools", "wheel", "Cython<3.0"]

--- a/acurl/setup.cfg
+++ b/acurl/setup.cfg
@@ -17,7 +17,7 @@ maintainer = Sky Identity NFT team
 maintainer_email = matthew.ellis@sky.uk
 license = MIT
 url = https://github.com/sky-uk/mite/tree/master/acurl
-version = 1.0.5
+version = 1.0.6
 
 [options]
 install_requires =


### PR DESCRIPTION
#### What is the change?
Cython version changed to <3.0 for acurl build to fix the error following latest release of [Cython 3.0.0](https://pypi.org/project/Cython/#history).

```
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error
  ....
  Cython.Compiler.Errors.CompileError: src/acurl.pyx
```

#### Does this change require a version increment:

- [ ] Major
- [ ] Minor
- [x] Patch
