### PR TITLE
Disable ci jobs temporarily  

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,143 +1,143 @@
-version: 2.1
+# version: 2.1
 
-# Further ideas for jobs to run:
-# - license check
-# - make sure test coverage increases
-# - merge all tox tests into one using pyenv
-# And, once we're sure that the pipeline is working:
-# - integration/performance tests
-# Once we have docs:
-# - documentation coverage
-# - docs build (on master only)
+# # Further ideas for jobs to run:
+# # - license check
+# # - make sure test coverage increases
+# # - merge all tox tests into one using pyenv
+# # And, once we're sure that the pipeline is working:
+# # - integration/performance tests
+# # Once we have docs:
+# # - documentation coverage
+# # - docs build (on master only)
 
-workflows:
-  mite:
-    jobs:
-      - check-acurl-version
-      - build:
-          requires:
-            - check-acurl-version
-      - tag:
-          requires:
-            - build
-          filters:
-            branches:
-              only: master
-      - linux-wheels:
-          requires:
-            - tag
-          filters:
-            branches:
-              only: master
+# workflows:
+#   mite:
+#     jobs:
+#       - check-acurl-version
+#       - build:
+#           requires:
+#             - check-acurl-version
+#       - tag:
+#           requires:
+#             - build
+#           filters:
+#             branches:
+#               only: master
+#       - linux-wheels:
+#           requires:
+#             - tag
+#           filters:
+#             branches:
+#               only: master
 
-jobs:
+# jobs:
 
-  check-acurl-version:
-    docker:
-      - image: python:3.11.2
-    steps:
-      - checkout
-      - run:
-          command: |
-            ACURL_CHANGED=false
-            if [[ -n $(git show --name-only ${CIRCLE_SHA1} ./acurl) ]]; then
-              echo "Acurl has changed"
-              apt-get update && apt-get install -y jq
-              ACURL_CHANGED=true
-              LATEST_ACURL_VERSION=$(curl -s https://pypi.org/pypi/acurl/json | jq -r '.info .version')
-              if [[ -n $(grep "version = $LATEST_ACURL_VERSION$" acurl/setup.cfg) ]]; then
-                echo "Acurl has changed, but the version of acurl hasn't changed"
-                exit 1
-              fi
-            fi
-            mkdir -p /tmp/workspace
-            echo "export ACURL_CHANGED=\"$ACURL_CHANGED\"" >> /tmp/workspace/env_vars
-      - persist_to_workspace:
-          root: /tmp/workspace
-          paths:
-            - env_vars
+#   check-acurl-version:
+#     docker:
+#       - image: python:3.11.2
+#     steps:
+#       - checkout
+#       - run:
+#           command: |
+#             ACURL_CHANGED=false
+#             if [[ -n $(git show --name-only ${CIRCLE_SHA1} ./acurl) ]]; then
+#               echo "Acurl has changed"
+#               apt-get update && apt-get install -y jq
+#               ACURL_CHANGED=true
+#               LATEST_ACURL_VERSION=$(curl -s https://pypi.org/pypi/acurl/json | jq -r '.info .version')
+#               if [[ -n $(grep "version = $LATEST_ACURL_VERSION$" acurl/setup.cfg) ]]; then
+#                 echo "Acurl has changed, but the version of acurl hasn't changed"
+#                 exit 1
+#               fi
+#             fi
+#             mkdir -p /tmp/workspace
+#             echo "export ACURL_CHANGED=\"$ACURL_CHANGED\"" >> /tmp/workspace/env_vars
+#       - persist_to_workspace:
+#           root: /tmp/workspace
+#           paths:
+#             - env_vars
 
-  build:
-    docker:
-      - image: python:3.11.2
-    environment:
-      PYENV_ROOT: /root/.pyenv
-      PYTHON_VERSION: 3.11.2
-      PIPENV_DEFAULT_PYTHON_VERSION: 3.11.2
-    steps:
-      - checkout
-      - run:
-          name: Install pyenv, run tox
-          command: |
-            echo 'export PATH="/root/.pyenv/shims:/root/.pyenv/bin:$PATH"' >> "$BASH_ENV"
-            source "$BASH_ENV"
-            curl https://pyenv.run | bash
-            for version in 3.9.16 3.10.10 3.11.2; do
-              pyenv install $version
-            done
-            pyenv local 3.11.2 3.10.10 3.9.16
-            pip install tox
-            tox
+#   build:
+#     docker:
+#       - image: python:3.11.2
+#     environment:
+#       PYENV_ROOT: /root/.pyenv
+#       PYTHON_VERSION: 3.11.2
+#       PIPENV_DEFAULT_PYTHON_VERSION: 3.11.2
+#     steps:
+#       - checkout
+#       - run:
+#           name: Install pyenv, run tox
+#           command: |
+#             echo 'export PATH="/root/.pyenv/shims:/root/.pyenv/bin:$PATH"' >> "$BASH_ENV"
+#             source "$BASH_ENV"
+#             curl https://pyenv.run | bash
+#             for version in 3.9.16 3.10.10 3.11.2; do
+#               pyenv install $version
+#             done
+#             pyenv local 3.11.2 3.10.10 3.9.16
+#             pip install tox
+#             tox
 
-  tag:
-    docker:
-      - image: python:3.11.2
-    steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "fc:39:a2:b8:32:23:52:a5:fe:45:b6:9b:12:e7:30:2a"
-      - checkout
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          name: tag github version
-          command: |
-            git config user.email "mite@noreply.github.com"
-            git config user.name "CircleCI"
-            pip3 install docopt GitPython packaging requests
-            python3 cd-scripts/cdRelease.py
-      - persist_to_workspace:
-          root: /tmp/workspace
-          paths:
-            - env_vars
+#   tag:
+#     docker:
+#       - image: python:3.11.2
+#     steps:
+#       - add_ssh_keys:
+#           fingerprints:
+#             - "fc:39:a2:b8:32:23:52:a5:fe:45:b6:9b:12:e7:30:2a"
+#       - checkout
+#       - attach_workspace:
+#           at: /tmp/workspace
+#       - run:
+#           name: tag github version
+#           command: |
+#             git config user.email "mite@noreply.github.com"
+#             git config user.name "CircleCI"
+#             pip3 install docopt GitPython packaging requests
+#             python3 cd-scripts/cdRelease.py
+#       - persist_to_workspace:
+#           root: /tmp/workspace
+#           paths:
+#             - env_vars
 
-  linux-wheels:
-    # we only need to build the 'mite' wheels on one platform
-    # so we only need to run `python3 -m build` in this job
-    working_directory: ~/linux-wheels
-    docker:
-      - image: python:3.11.2
-    environment:
-      CIBW_BEFORE_ALL_LINUX: "yum install -y libcurl-devel || apt-get install -y libcurl-dev || apk add curl-dev"
-      CIBW_SKIP: "*i686"
-    steps:
-      - checkout
-      - setup_remote_docker
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          name: Build the Linux wheels.
-          command: |
-            source /tmp/workspace/env_vars
-            if [ "$VERSION_INCREMENT" = false ]; then
-              echo "Mite version not incremented, not building"
-            else
-              pip3 install --user cibuildwheel==2.8.1 build twine
-              python3 -m build --outdir ./wheelhouse
-            fi
-            if [ "$ACURL_CHANGED" = true ]; then
-              cd acurl
-              pip3 install --user cibuildwheel==2.8.1 build Cython twine
-              python3 -m build --sdist --outdir ../wheelhouse
-            fi
-      - run:
-          name: init .pypirc
-          command: |
-            echo -e "[pypi]" >> ~/.pypirc
-            echo -e "username = __token__" >> ~/.pypirc
-            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
-      - run:
-          name: upload packages to pypi
-          command: /root/.local/bin/twine upload wheelhouse/*
-      - store_artifacts:
-          path: wheelhouse/
+#   linux-wheels:
+#     # we only need to build the 'mite' wheels on one platform
+#     # so we only need to run `python3 -m build` in this job
+#     working_directory: ~/linux-wheels
+#     docker:
+#       - image: python:3.11.2
+#     environment:
+#       CIBW_BEFORE_ALL_LINUX: "yum install -y libcurl-devel || apt-get install -y libcurl-dev || apk add curl-dev"
+#       CIBW_SKIP: "*i686"
+#     steps:
+#       - checkout
+#       - setup_remote_docker
+#       - attach_workspace:
+#           at: /tmp/workspace
+#       - run:
+#           name: Build the Linux wheels.
+#           command: |
+#             source /tmp/workspace/env_vars
+#             if [ "$VERSION_INCREMENT" = false ]; then
+#               echo "Mite version not incremented, not building"
+#             else
+#               pip3 install --user cibuildwheel==2.8.1 build twine
+#               python3 -m build --outdir ./wheelhouse
+#             fi
+#             if [ "$ACURL_CHANGED" = true ]; then
+#               cd acurl
+#               pip3 install --user cibuildwheel==2.8.1 build Cython twine
+#               python3 -m build --sdist --outdir ../wheelhouse
+#             fi
+#       - run:
+#           name: init .pypirc
+#           command: |
+#             echo -e "[pypi]" >> ~/.pypirc
+#             echo -e "username = __token__" >> ~/.pypirc
+#             echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
+#       - run:
+#           name: upload packages to pypi
+#           command: /root/.local/bin/twine upload wheelhouse/*
+#       - store_artifacts:
+#           path: wheelhouse/

--- a/cd.yml
+++ b/cd.yml
@@ -1,9 +1,9 @@
 version: 1
-context: identity
+context: sky-identity
 triggering: multibranch
 
 defaultNodes:
-  default: id-mite-slave
+  default: sky-identity-nonprod-mite-slave-buildkit
 
 modules:
   mite-ci:


### PR DESCRIPTION
Temporarily disable the ci jobs while looking for another platform to run them as the parent department moved away from circle-ci.