### PR TITLE
Add end of scenario report

### DIFF
--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -90,6 +90,7 @@ Options:
     --message-processors=PROCESSORS           Classes to connect to the message bus for local testing [default: mite.logoutput:HttpStatsOutput,mite.logoutput:MsgOutput]
     --prettify-timestamps                     Reformat unix timestamps to human readable dates
     --journey-logging                         Log errors on a per journey basis
+    --report                                  Report stats at the end of the test
     --hide-constant-logs                      Hide logs that are printed every 2 seconds
     --max-errors-threshold=THRESHOLD          Set the maximum number of errors accepted before setting exit status to 1 [default: 0]
     --max-response-time-threshold=THRESHOLD   Set the maximum response time accepted before setting exit status to 1 [default: 0]

--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -92,7 +92,7 @@ Options:
     --journey-logging                         Log errors on a per journey basis
     --hide-constant-logs                      Hide logs that are printed every 2 seconds
     --max-errors-threshold=THRESHOLD          Set the maximum number of errors accepted before setting exit status to 1 [default: 0]
-    --max-response-time-threshold=THRESHOLD   Set the maximum mean response time accepted before setting exit status to 1 [default: 0]
+    --max-response-time-threshold=THRESHOLD   Set the maximum response time accepted before setting exit status to 1 [default: 0]
     --mean-response-time-threshold=THRESHOLD  Set the mean response time accepted before setting exit status to 1 [default: 0]
 """
 import asyncio

--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -56,41 +56,44 @@ Examples:
 
 
 Options:
-    -h --help                               Show this screen
-    --version                               Show version
-    --debugging                             Drop into debugger (pdb) on journey error and exit.  Select debugger with PYTHONBREAKPOINT and PYTHONPOSTMORTEM
-    --memory-tracing                        Print heap alloc diffs every 60 seconds
-    --log-level=LEVEL                       Set logger level, one of DEBUG, INFO, WARNING, ERROR, CRITICAL [default: INFO]
-    --config=CONFIG_SPEC                    Set a config loader to a callable loaded via a spec [default: mite.config:default_config_loader]
-    --add-to-config=NEW_VALUE               Add a key:value to the config map, in addition to what's loaded from a file
-    --spawn-rate=NUM_PER_SECOND             Maximum spawn rate [default: 1000]
-    --max-loop-delay=SECONDS                Runner internal loop delay maximum [default: 1]
-    --min-loop-delay=SECONDS                Runner internal loop delay minimum [default: 0]
-    --runner-max-journeys=NUMBER            Max number of concurrent journeys a runner can run
-    --controller-socket=SOCKET              Controller socket [default: tcp://127.0.0.1:14301]
-    --message-socket=SOCKET                 Message socket [default: tcp://127.0.0.1:14302]
-    --collector-socket=SOCKET               Socket [default: tcp://127.0.0.1:14303]
-    --stats-in-socket=SOCKET                Socket [default: tcp://127.0.0.1:14304]
-    --stats-out-socket=SOCKET               Socket [default: tcp://127.0.0.1:14305]
-    --stats-include-processors=PROCESSORS   Stats processor names to include, as a comma separated list (no spaces)
-    --stats-exclude-processors=PROCESSORS   Stats processor names to exclude, as a comma separated list (no spaces)
-    --recorder-socket=SOCKET                Socket [default: tcp://127.0.0.1:14306]
-    --delay-start-seconds=DELAY             Delay start allowing others to connect [default: 0]
-    --volume=VOLUME                         Volume to run journey at [default: 1]
-    --web-address=HOST_PORT                 Web bind address [default: 127.0.0.1:9301]
-    --message-backend=BACKEND               Backend to transport messages over [default: ZMQ]
-    --exclude-working-directory             By default mite puts the current directory on the python path
-    --collector-dir=DIRECTORY               Set the collectors output directory [default: collector_data]
-    --collector-filter=SPEC                 Function spec to filter messages collected by the collector
-    --collector-roll=NUM_LINES              How many lines per collector output file [default: 100000]
-    --collector-use-json                    Output in json format rather than msgpack
-    --recorder-dir=DIRECTORY                Set the recorders output directory [default: recorder_data]
-    --sleep-time=SLEEP                      Set the second to await between each request [default: 1]
-    --logging-webhook=URL                   URL of an HTTP server to log test runs to
-    --message-processors=PROCESSORS         Classes to connect to the message bus for local testing [default: mite.logoutput:HttpStatsOutput,mite.logoutput:MsgOutput]
-    --prettify-timestamps                   Reformat unix timestamps to human readable dates
-    --journey-logging                       Log errors on a per journey basis
-    --max-errors-threshold=THRESHOLD        Set the maximum number of errors accepted before setting exit status to 1 [default: 0]
+    -h --help                                 Show this screen
+    --version                                 Show version
+    --debugging                               Drop into debugger (pdb) on journey error and exit.  Select debugger with PYTHONBREAKPOINT and PYTHONPOSTMORTEM
+    --memory-tracing                          Print heap alloc diffs every 60 seconds
+    --log-level=LEVEL                         Set logger level, one of DEBUG, INFO, WARNING, ERROR, CRITICAL [default: INFO]
+    --config=CONFIG_SPEC                      Set a config loader to a callable loaded via a spec [default: mite.config:default_config_loader]
+    --add-to-config=NEW_VALUE                 Add a key:value to the config map, in addition to what's loaded from a file
+    --spawn-rate=NUM_PER_SECOND               Maximum spawn rate [default: 1000]
+    --max-loop-delay=SECONDS                  Runner internal loop delay maximum [default: 1]
+    --min-loop-delay=SECONDS                  Runner internal loop delay minimum [default: 0]
+    --runner-max-journeys=NUMBER              Max number of concurrent journeys a runner can run
+    --controller-socket=SOCKET                Controller socket [default: tcp://127.0.0.1:14301]
+    --message-socket=SOCKET                   Message socket [default: tcp://127.0.0.1:14302]
+    --collector-socket=SOCKET                 Socket [default: tcp://127.0.0.1:14303]
+    --stats-in-socket=SOCKET                  Socket [default: tcp://127.0.0.1:14304]
+    --stats-out-socket=SOCKET                 Socket [default: tcp://127.0.0.1:14305]
+    --stats-include-processors=PROCESSORS     Stats processor names to include, as a comma separated list (no spaces)
+    --stats-exclude-processors=PROCESSORS     Stats processor names to exclude, as a comma separated list (no spaces)
+    --recorder-socket=SOCKET                  Socket [default: tcp://127.0.0.1:14306]
+    --delay-start-seconds=DELAY               Delay start allowing others to connect [default: 0]
+    --volume=VOLUME                           Volume to run journey at [default: 1]
+    --web-address=HOST_PORT                   Web bind address [default: 127.0.0.1:9301]
+    --message-backend=BACKEND                 Backend to transport messages over [default: ZMQ]
+    --exclude-working-directory               By default mite puts the current directory on the python path
+    --collector-dir=DIRECTORY                 Set the collectors output directory [default: collector_data]
+    --collector-filter=SPEC                   Function spec to filter messages collected by the collector
+    --collector-roll=NUM_LINES                How many lines per collector output file [default: 100000]
+    --collector-use-json                      Output in json format rather than msgpack
+    --recorder-dir=DIRECTORY                  Set the recorders output directory [default: recorder_data]
+    --sleep-time=SLEEP                        Set the second to await between each request [default: 1]
+    --logging-webhook=URL                     URL of an HTTP server to log test runs to
+    --message-processors=PROCESSORS           Classes to connect to the message bus for local testing [default: mite.logoutput:HttpStatsOutput,mite.logoutput:MsgOutput]
+    --prettify-timestamps                     Reformat unix timestamps to human readable dates
+    --journey-logging                         Log errors on a per journey basis
+    --hide-constant-logs                      Hide logs that are printed every 2 seconds
+    --max-errors-threshold=THRESHOLD          Set the maximum number of errors accepted before setting exit status to 1 [default: 0]
+    --max-response-time-threshold=THRESHOLD   Set the maximum mean response time accepted before setting exit status to 1 [default: 0]
+    --mean-response-time-threshold=THRESHOLD  Set the mean response time accepted before setting exit status to 1 [default: 0]
 """
 import asyncio
 import logging

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -171,16 +171,6 @@ def test_scenarios(test_name, opts, scenarios, config_manager):
 def benchmark_report(opts, http_stats_output):
     has_error = False
 
-    report_output_w_stddev = """
-
-Benchmark Report
-
-\t\tAvg\t\tMin\t\tMax\t\tStd Dev\t\t+/- Std Dev
-Latency\t\t{mean_resp_time:.2f}ms\t\t{min_resp_time:.2f}ms\t\t{max_resp_time:.2f}ms\t{std_dev_resp_time:.2f}ms\t+/- {std_dev_resp_time:.2f}ms
-Req/Sec\t\t{req_per_sec:.2f}\t\t{min_req_per_sec:.2f}\t\t{max_req_per_sec:.2f}\t\t{std_dev_req_per_sec:.2f}\t\t+/- {std_dev_req_per_sec:.2f}
-
-{total_reqs} requests in {total_time:.2f}s, {data_transfer:.2f} {data_unit} data transfered
-"""
     report_output = """
 
 Benchmark Report
@@ -220,20 +210,6 @@ Req/Sec\t\t{req_per_sec_mean:.2f}\t\t{min_req_per_sec:.2f}\t\t{max_req_per_sec:.
         data_transfer=http_stats_output._data_transferred,
         data_unit="B",
     ))
-    # print(report_output_w_stddev.format(
-    #     mean_resp_time=http_stats_output.mean_resp_time * 1000,
-    #     min_resp_time=http_stats_output._resp_time_min * 1000,
-    #     max_resp_time=http_stats_output._resp_time_max * 1000,
-    #     std_dev_resp_time=999,
-    #     req_per_sec=999,
-    #     min_req_per_sec=999,
-    #     max_req_per_sec=999,
-    #     std_dev_req_per_sec=999,
-    #     total_reqs=999,
-    #     total_time=999,
-    #     data_transfer=999,
-    #     data_unit="KB",
-    # ))
 
     return has_error
 

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -158,6 +158,22 @@ def test_scenarios(test_name, opts, scenarios, config_manager):
         opts.get("--max-errors-threshold")
     )
 
+    if opts.get("--max-response-time-threshold") != "0":
+        max_response_time = http_stats_output._resp_time_max * 1000
+        if max_response_time > int(opts["--max-response-time-threshold"]):
+            has_error = True
+
+            logging.error(
+                "Max response time exceeded: %sms", max_response_time
+            )
+    if opts.get("--mean-response-time-threshold") != "0":
+        mean_response_time = http_stats_output.mean_resp_time * 1000
+        if mean_response_time > int(opts["--mean-response-time-threshold"]):
+            has_error = True
+            logging.error(
+                "Mean response time exceeded: %sms", mean_response_time
+            )
+
     # Ensure any open files get closed
     del receiver._raw_listeners
     del receiver._listeners

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -162,7 +162,6 @@ def test_scenarios(test_name, opts, scenarios, config_manager):
         max_response_time = http_stats_output._resp_time_max * 1000
         if max_response_time > int(opts["--max-response-time-threshold"]):
             has_error = True
-
             logging.error(
                 "Max response time exceeded: %sms", max_response_time
             )

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -118,7 +118,6 @@ class GenericStatsOutput:
             self._resp_time_mean_store.append(mean_resp_time)
 
             self.print_output(t)
-
         if msg_type in self.message_types:
             self._resp_time_recent.append(message["total_time"])
             self._req_total += 1

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -57,8 +57,6 @@ class GenericStatsOutput:
         self._resp_time_mean_store = []
         self._req_sec_min = 0
         self._req_sec_max = 0
-        self._req_sec_mean = 0
-        self._req_sec_mean_store = []
         self._scenarios_completed_time = 0
         self._data_transferred = 0
         self._error_journeys = defaultdict(int)

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -128,12 +128,12 @@ class GenericStatsOutput:
 
                 self._resp_time_max = max(self.max_resp_time_recent, self._resp_time_max)
 
-            mean_resp_time = sum(self._resp_time_recent) / len(self._resp_time_recent)
-            self._resp_time_mean_store.append(mean_resp_time)
+            self._resp_time_mean_store.append(
+                sum(self._resp_time_recent) / len(self._resp_time_recent)
+            )
 
             if self._req_recent:
-                dt = t - self._start_t
-                req_sec = self._req_recent / dt
+                req_sec = self._req_recent / (t - self._start_t)
                 if self._req_sec_min == 0:
                     self._req_sec_min = req_sec
                 else:

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -59,6 +59,7 @@ class GenericStatsOutput:
         self._req_sec_max = 0
         self._req_sec_mean = 0
         self._req_sec_mean_store = []
+        self._scenarios_completed_time = 0
         self._data_transferred = 0
         self._error_journeys = defaultdict(int)
 
@@ -130,7 +131,6 @@ class GenericStatsOutput:
             mean_resp_time = sum(self._resp_time_recent) / len(self._resp_time_recent)
             self._resp_time_mean_store.append(mean_resp_time)
 
-
             if self._req_recent:
                 dt = t - self._start_t
                 req_sec = self._req_recent / dt
@@ -171,6 +171,10 @@ class GenericStatsOutput:
         if not self._resp_time_recent:
             return 0
         return min(self._resp_time_recent)
+
+    @property
+    def req_sec_mean(self):
+        return self._req_total / (self._scenarios_completed_time - self._init_time)
 
 
 class HttpStatsOutput(GenericStatsOutput):

--- a/mite_http/__init__.py
+++ b/mite_http/__init__.py
@@ -82,6 +82,7 @@ class SessionPool:
                 total_time=r.total_time,
                 primary_ip=r.primary_ip,
                 method=r.request.method,
+                download_size=r.download_size,
                 **session_wrapper.additional_metrics,
             )
 


### PR DESCRIPTION
#### What is the change?

Adds the following options:

```
    --report                                  Report stats at the end of the test
    --hide-constant-logs                      Hide logs that are printed every 2 seconds
    --max-response-time-threshold=THRESHOLD   Set the maximum response time accepted before setting exit status to 1 [default: 0]
    --mean-response-time-threshold=THRESHOLD  Set the mean response time accepted before setting exit status to 1 [default: 0]
```

`--report` will print out a report , e.g.
```
                Avg             Min             Max
Latency         40.75ms         1.90ms          1026.44ms
Req/Sec         9.97            9.48            10.50

110 requests in 11.03s, 260.61KB data transfered
```

`--hide-constant-logs` will stop the 2 second interval output that shows req/s and response percentiles.

The two threshold options will set a `1` exit code if response times breach the given threshold.


#### Does this change require a version increment:

- [ ] Major
- [x] Minor
- [ ] Patch
