### PR TITLE
remove deprecated version key from docker compose

### DIFF
--- a/acurl/tests/test_acurl.py
+++ b/acurl/tests/test_acurl.py
@@ -9,7 +9,7 @@ import acurl
 @pytest.mark.asyncio
 async def test_non_zero_exit_code_raises(acurl_session):
     with pytest.raises(
-        acurl.AcurlError, match="curl failed with code 6 Couldn't resolve host name"
+        acurl.AcurlError, match="curl failed with code 6 Could not resolve hostname"
     ):
         # Curl returns CURLE_COULDNT_RESOLVE_HOST (6) exit code
         await acurl_session.get("unresolvable_hostname.doesnotexist")

--- a/docker_compose.yml
+++ b/docker_compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   apiserver:
     image: python:3.11-alpine3.16

--- a/docker_compose_monitoring.yml
+++ b/docker_compose_monitoring.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   prometheus:
     image: "prom/prometheus:latest"


### PR DESCRIPTION
#### What is the change?

Version key is deprecated and now longer used

#### Does this change require a version increment:

- [ ] Major
- [ ] Minor
- [x] Patch
