### PR TITLE
Stddev benchmark

### DIFF
--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -96,6 +96,7 @@ Options:
     --max-response-time-threshold=THRESHOLD                 Set the maximum response time accepted before setting exit status to 1 [default: 0]
     --mean-response-time-threshold=THRESHOLD                Set the mean response time accepted before setting exit status to 1 [default: 0]
     --standard-deviation-response-time-threshold=THRESHOLD  Set the response time standard deviation accepted before setting exit status to 1 [default: 0]
+    --standard-deviation-req-sec-threshold=THRESHOLD      Set the request per second standard deviation accepted before setting exit status to 1 [default: 0]
 """
 import asyncio
 import logging

--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -95,6 +95,7 @@ Options:
     --max-errors-threshold=THRESHOLD          Set the maximum number of errors accepted before setting exit status to 1 [default: 0]
     --max-response-time-threshold=THRESHOLD   Set the maximum response time accepted before setting exit status to 1 [default: 0]
     --mean-response-time-threshold=THRESHOLD  Set the mean response time accepted before setting exit status to 1 [default: 0]
+    --response-time-standard-deviation-threshold=THRESHOLD Set the standard deviation in response time accepted before setting exit status to 1 [default: 0]
 """
 import asyncio
 import logging

--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -56,46 +56,46 @@ Examples:
 
 
 Options:
-    -h --help                                 Show this screen
-    --version                                 Show version
-    --debugging                               Drop into debugger (pdb) on journey error and exit.  Select debugger with PYTHONBREAKPOINT and PYTHONPOSTMORTEM
-    --memory-tracing                          Print heap alloc diffs every 60 seconds
-    --log-level=LEVEL                         Set logger level, one of DEBUG, INFO, WARNING, ERROR, CRITICAL [default: INFO]
-    --config=CONFIG_SPEC                      Set a config loader to a callable loaded via a spec [default: mite.config:default_config_loader]
-    --add-to-config=NEW_VALUE                 Add a key:value to the config map, in addition to what's loaded from a file
-    --spawn-rate=NUM_PER_SECOND               Maximum spawn rate [default: 1000]
-    --max-loop-delay=SECONDS                  Runner internal loop delay maximum [default: 1]
-    --min-loop-delay=SECONDS                  Runner internal loop delay minimum [default: 0]
-    --runner-max-journeys=NUMBER              Max number of concurrent journeys a runner can run
-    --controller-socket=SOCKET                Controller socket [default: tcp://127.0.0.1:14301]
-    --message-socket=SOCKET                   Message socket [default: tcp://127.0.0.1:14302]
-    --collector-socket=SOCKET                 Socket [default: tcp://127.0.0.1:14303]
-    --stats-in-socket=SOCKET                  Socket [default: tcp://127.0.0.1:14304]
-    --stats-out-socket=SOCKET                 Socket [default: tcp://127.0.0.1:14305]
-    --stats-include-processors=PROCESSORS     Stats processor names to include, as a comma separated list (no spaces)
-    --stats-exclude-processors=PROCESSORS     Stats processor names to exclude, as a comma separated list (no spaces)
-    --recorder-socket=SOCKET                  Socket [default: tcp://127.0.0.1:14306]
-    --delay-start-seconds=DELAY               Delay start allowing others to connect [default: 0]
-    --volume=VOLUME                           Volume to run journey at [default: 1]
-    --web-address=HOST_PORT                   Web bind address [default: 127.0.0.1:9301]
-    --message-backend=BACKEND                 Backend to transport messages over [default: ZMQ]
-    --exclude-working-directory               By default mite puts the current directory on the python path
-    --collector-dir=DIRECTORY                 Set the collectors output directory [default: collector_data]
-    --collector-filter=SPEC                   Function spec to filter messages collected by the collector
-    --collector-roll=NUM_LINES                How many lines per collector output file [default: 100000]
-    --collector-use-json                      Output in json format rather than msgpack
-    --recorder-dir=DIRECTORY                  Set the recorders output directory [default: recorder_data]
-    --sleep-time=SLEEP                        Set the second to await between each request [default: 1]
-    --logging-webhook=URL                     URL of an HTTP server to log test runs to
-    --message-processors=PROCESSORS           Classes to connect to the message bus for local testing [default: mite.logoutput:HttpStatsOutput,mite.logoutput:MsgOutput]
-    --prettify-timestamps                     Reformat unix timestamps to human readable dates
-    --journey-logging                         Log errors on a per journey basis
-    --report                                  Report stats at the end of the test
-    --hide-constant-logs                      Hide logs that are printed every 2 seconds
-    --max-errors-threshold=THRESHOLD          Set the maximum number of errors accepted before setting exit status to 1 [default: 0]
-    --max-response-time-threshold=THRESHOLD   Set the maximum response time accepted before setting exit status to 1 [default: 0]
-    --mean-response-time-threshold=THRESHOLD  Set the mean response time accepted before setting exit status to 1 [default: 0]
-    --response-time-standard-deviation-threshold=THRESHOLD Set the standard deviation in response time accepted before setting exit status to 1 [default: 0]
+    -h --help                                               Show this screen
+    --version                                               Show version
+    --debugging                                             Drop into debugger (pdb) on journey error and exit.  Select debugger with PYTHONBREAKPOINT and PYTHONPOSTMORTEM
+    --memory-tracing                                        Print heap alloc diffs every 60 seconds
+    --log-level=LEVEL                                       Set logger level, one of DEBUG, INFO, WARNING, ERROR, CRITICAL [default: INFO]
+    --config=CONFIG_SPEC                                    Set a config loader to a callable loaded via a spec [default: mite.config:default_config_loader]
+    --add-to-config=NEW_VALUE                               Add a key:value to the config map, in addition to what's loaded from a file
+    --spawn-rate=NUM_PER_SECOND                             Maximum spawn rate [default: 1000]
+    --max-loop-delay=SECONDS                                Runner internal loop delay maximum [default: 1]
+    --min-loop-delay=SECONDS                                Runner internal loop delay minimum [default: 0]
+    --runner-max-journeys=NUMBER                            Max number of concurrent journeys a runner can run
+    --controller-socket=SOCKET                              Controller socket [default: tcp://127.0.0.1:14301]
+    --message-socket=SOCKET                                 Message socket [default: tcp://127.0.0.1:14302]
+    --collector-socket=SOCKET                               Socket [default: tcp://127.0.0.1:14303]
+    --stats-in-socket=SOCKET                                Socket [default: tcp://127.0.0.1:14304]
+    --stats-out-socket=SOCKET                               Socket [default: tcp://127.0.0.1:14305]
+    --stats-include-processors=PROCESSORS                   Stats processor names to include, as a comma separated list (no spaces)
+    --stats-exclude-processors=PROCESSORS                   Stats processor names to exclude, as a comma separated list (no spaces)
+    --recorder-socket=SOCKET                                Socket [default: tcp://127.0.0.1:14306]
+    --delay-start-seconds=DELAY                             Delay start allowing others to connect [default: 0]
+    --volume=VOLUME                                         Volume to run journey at [default: 1]
+    --web-address=HOST_PORT                                 Web bind address [default: 127.0.0.1:9301]
+    --message-backend=BACKEND                               Backend to transport messages over [default: ZMQ]
+    --exclude-working-directory                             By default mite puts the current directory on the python path
+    --collector-dir=DIRECTORY                               Set the collectors output directory [default: collector_data]
+    --collector-filter=SPEC                                 Function spec to filter messages collected by the collector
+    --collector-roll=NUM_LINES                              How many lines per collector output file [default: 100000]
+    --collector-use-json                                    Output in json format rather than msgpack
+    --recorder-dir=DIRECTORY                                Set the recorders output directory [default: recorder_data]
+    --sleep-time=SLEEP                                      Set the second to await between each request [default: 1]
+    --logging-webhook=URL                                   URL of an HTTP server to log test runs to
+    --message-processors=PROCESSORS                         Classes to connect to the message bus for local testing [default: mite.logoutput:HttpStatsOutput,mite.logoutput:MsgOutput]
+    --prettify-timestamps                                   Reformat unix timestamps to human readable dates
+    --journey-logging                                       Log errors on a per journey basis
+    --report                                                Report stats at the end of the test
+    --hide-constant-logs                                    Hide logs that are printed every 2 seconds
+    --max-errors-threshold=THRESHOLD                        Set the maximum number of errors accepted before setting exit status to 1 [default: 0]
+    --max-response-time-threshold=THRESHOLD                 Set the maximum response time accepted before setting exit status to 1 [default: 0]
+    --mean-response-time-threshold=THRESHOLD                Set the mean response time accepted before setting exit status to 1 [default: 0]
+    --standard-deviation-response-time-threshold=THRESHOLD  Set the response time standard deviation accepted before setting exit status to 1 [default: 0]
 """
 import asyncio
 import logging

--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -96,7 +96,7 @@ Options:
     --max-response-time-threshold=THRESHOLD                 Set the maximum response time accepted before setting exit status to 1 [default: 0]
     --mean-response-time-threshold=THRESHOLD                Set the mean response time accepted before setting exit status to 1 [default: 0]
     --standard-deviation-response-time-threshold=THRESHOLD  Set the response time standard deviation accepted before setting exit status to 1 [default: 0]
-    --standard-deviation-req-sec-threshold=THRESHOLD      Set the request per second standard deviation accepted before setting exit status to 1 [default: 0]
+    --standard-deviation-req-sec-threshold=THRESHOLD        Set the request per second standard deviation accepted before setting exit status to 1 [default: 0]
 """
 import asyncio
 import logging

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -196,10 +196,10 @@ def benchmark_report(opts, http_stats_output):
 Report
 
 Metric\t\tAvg\t\tMin\t\tMax\t\tStd Dev\t\t+/- Std Dev
-------------------------------------------------------------------------------------------
-Latency\t\t{mean_resp_time:.2f}ms\t{min_resp_time:.2f}ms\t{max_resp_time:.2f}ms\t{std_dev_resp_time:.2f}ms\t\t+/- {std_dev_resp_time:.2f}ms
-Req/Sec\t\t{req_per_sec_mean:.2f}\t\t{min_req_per_sec:.2f}\t\t{max_req_per_sec:.2f}\t\t{std_dev_req_per_sec:.2f}\t\t+/- {std_dev_req_per_sec:.2f}
-------------------------------------------------------------------------------------------
+---------------------------------------------------------------------------------------------
+Latency\t\t{mean_resp_time:.2f}ms\t{min_resp_time:.2f}ms\t{max_resp_time:.2f}ms\t{std_dev_resp_time:.2f}ms\t\t {resp_time_within_stddev:.2f}%
+Req/Sec\t\t{req_per_sec_mean:.2f}\t\t{min_req_per_sec:.2f}\t\t{max_req_per_sec:.2f}\t\t{std_dev_req_per_sec:.2f}\t\t {req_sec_within_stddev:.2f}%
+---------------------------------------------------------------------------------------------
 {total_reqs} requests in {total_time:.2f}s, {data_transfer:.2f} {data_unit} data transferred
 """
     data_transfer, data_unit = human_readable_bytes(http_stats_output._data_transferred)
@@ -212,8 +212,10 @@ Req/Sec\t\t{req_per_sec_mean:.2f}\t\t{min_req_per_sec:.2f}\t\t{max_req_per_sec:.
             req_per_sec_mean=http_stats_output.req_sec_mean,
             min_req_per_sec=http_stats_output._req_sec_min,
             max_req_per_sec=http_stats_output._req_sec_max,
-            std_dev_resp_time=http_stats_output.resp_time_standard_deviation,
+            std_dev_resp_time=http_stats_output.resp_time_standard_deviation * 1000,
             std_dev_req_per_sec=http_stats_output.req_sec_standard_deviation,
+            resp_time_within_stddev=http_stats_output.resp_time_within_standard_deviation,
+            req_sec_within_stddev=http_stats_output.req_sec_within_standard_deviation,
             total_reqs=http_stats_output._req_total,
             total_time=http_stats_output._scenarios_completed_time
             - http_stats_output._init_time,

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -181,6 +181,12 @@ def test_scenarios(test_name, opts, scenarios, config_manager):
             has_error = True
             logging.error("Response time standard deviation exceeded: %sms", resp_time_stddev)
 
+    if opts.get("--standard-deviation-req-sec-threshold") != "0":
+        req_sec_stddev = http_stats_output.req_sec_standard_deviation
+        if req_sec_stddev > int(opts["--standard-deviation-req-sec-threshold"]):
+            has_error = True
+            logging.error("Request per second exceeded: %s", req_sec_stddev)
+
     if opts.get("--report"):
         benchmark_report(http_stats_output)
    

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -193,13 +193,15 @@ def human_readable_bytes(size):
 def benchmark_report(opts, http_stats_output):
     report_output = """
 
-\t\tAvg\t\tMin\t\tMax
-Latency\t\t{mean_resp_time:.2f}ms\t\t{min_resp_time:.2f}ms\t\t{max_resp_time:.2f}ms
-Req/Sec\t\t{req_per_sec_mean:.2f}\t\t{min_req_per_sec:.2f}\t\t{max_req_per_sec:.2f}
+Report
 
-{total_reqs} requests in {total_time:.2f}s, {data_transfer:.2f}{data_unit} data transfered
+Metric\t\tAvg\t\tMin\t\tMax\t\tStd Dev\t\t+/- Std Dev
+------------------------------------------------------------------------------------------
+Latency\t\t{mean_resp_time:.2f}ms\t{min_resp_time:.2f}ms\t{max_resp_time:.2f}ms\t{std_dev_resp_time:.2f}ms\t\t+/- {std_dev_resp_time:.2f}ms
+Req/Sec\t\t{req_per_sec_mean:.2f}\t\t{min_req_per_sec:.2f}\t\t{max_req_per_sec:.2f}\t\t{std_dev_req_per_sec:.2f}\t\t+/- {std_dev_req_per_sec:.2f}
+------------------------------------------------------------------------------------------
+{total_reqs} requests in {total_time:.2f}s, {data_transfer:.2f} {data_unit} data transferred
 """
-
     data_transfer, data_unit = human_readable_bytes(http_stats_output._data_transferred)
 
     print(
@@ -210,6 +212,8 @@ Req/Sec\t\t{req_per_sec_mean:.2f}\t\t{min_req_per_sec:.2f}\t\t{max_req_per_sec:.
             req_per_sec_mean=http_stats_output.req_sec_mean,
             min_req_per_sec=http_stats_output._req_sec_min,
             max_req_per_sec=http_stats_output._req_sec_max,
+            std_dev_resp_time=http_stats_output.resp_time_standard_deviation,
+            std_dev_req_per_sec=http_stats_output.req_sec_standard_deviation,
             total_reqs=http_stats_output._req_total,
             total_time=http_stats_output._scenarios_completed_time
             - http_stats_output._init_time,

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -175,9 +175,9 @@ def test_scenarios(test_name, opts, scenarios, config_manager):
             has_error = True
             logging.error("Mean response time exceeded: %sms", mean_response_time)
 
-    if opts.get("--response-time-standard-deviation-threshold") != "0":
+    if opts.get("--standard-deviation-response-time-threshold") != "0":
         resp_time_stddev = http_stats_output.resp_time_standard_deviation * 1000
-        if resp_time_stddev > int(opts["--response-time-standard-deviation-threshold"]):
+        if resp_time_stddev > int(opts["--standard-deviation-response-time-threshold"]):
             has_error = True
             logging.error("Response time standard deviation exceeded: %sms", resp_time_stddev)
 
@@ -200,43 +200,11 @@ def human_readable_bytes(size):
     return size, "PB"
 
 
-# def benchmark_report(opts, http_stats_output):
-#     report_output = """
-# Report
-
-# Metric            Avg          Min          Max          Std Dev       +/- Std Dev
-# -----------------------------------------------------------------------------------
-# Latency      {mean_resp_time:>10.2f}ms  {min_resp_time:>10.2f}ms  {max_resp_time:>10.2f}ms  {std_dev_resp_time:>10.2f}ms  {resp_time_within_stddev:>10.2f}%
-# Req/Sec      {req_per_sec_mean:>10.2f}   {min_req_per_sec:>10.2f}   {max_req_per_sec:>10.2f}   {std_dev_req_per_sec:>10.2f}   {req_sec_within_stddev:>10.2f}%
-# -----------------------------------------------------------------------------------
-# {total_reqs} requests in {total_time:.2f}s, {data_transfer:.2f} {data_unit} data transferred
-# """
-#     data_transfer, data_unit = human_readable_bytes(http_stats_output._data_transferred)
-
-#     print(
-#         report_output.format(
-#             mean_resp_time=http_stats_output.mean_resp_time * 1000,
-#             min_resp_time=http_stats_output._resp_time_min * 1000,
-#             max_resp_time=http_stats_output._resp_time_max * 1000,
-#             req_per_sec_mean=http_stats_output.req_sec_mean,
-#             min_req_per_sec=http_stats_output._req_sec_min,
-#             max_req_per_sec=http_stats_output._req_sec_max,
-#             std_dev_resp_time=103.456577,#http_stats_output.resp_time_standard_deviation * 1000,
-#             std_dev_req_per_sec=http_stats_output.req_sec_standard_deviation,
-#             resp_time_within_stddev=http_stats_output.resp_time_within_standard_deviation,
-#             req_sec_within_stddev=http_stats_output.req_sec_within_standard_deviation,
-#             total_reqs=http_stats_output._req_total,
-#             total_time=http_stats_output._scenarios_completed_time
-#             - http_stats_output._init_time,
-#             data_transfer=data_transfer,
-#             data_unit=data_unit,
-#         )
-#     )
-
 def benchmark_report(http_stats_output):
     table = PrettyTable()
     table.field_names = ["Metric", "Avg", "Min", "Max", "Std Dev", "+/- Std Dev"]
-    
+    number_format = lambda number: f"{number / 1000:.2f}K" if number >= 1000 else f"{number:.2f}"
+
     table.add_row([
     "Latency",
     f"{http_stats_output.mean_resp_time * 1000:.2f}ms",
@@ -247,16 +215,17 @@ def benchmark_report(http_stats_output):
     
     table.add_row([
     "Req/Sec",
-    f"{http_stats_output.req_sec_mean:.2f}",
-    f"{http_stats_output._req_sec_min:.2f}",
-    f"{http_stats_output._req_sec_max:.2f}",
-    f"{http_stats_output.req_sec_standard_deviation:.2f}",
+    number_format(http_stats_output.req_sec_mean),
+    number_format(http_stats_output._req_sec_min),
+    number_format(http_stats_output._req_sec_max),
+    number_format(http_stats_output.req_sec_standard_deviation),
     f"{http_stats_output.req_sec_within_standard_deviation:.2f}%"])
 
     table.align["Metric"] = "l"
     data_transfer, data_unit = human_readable_bytes(http_stats_output._data_transferred)
     print(table)
     print(f"{http_stats_output._req_total} requests in {http_stats_output._scenarios_completed_time - http_stats_output._init_time:.2f}s, {data_transfer:.2f} {data_unit} data transferred")
+
 
 def scenario_test_cmd(opts):
     scenario_spec = opts["SCENARIO_SPEC"]

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -4,6 +4,7 @@ import logging
 import sys
 import time
 import tracemalloc
+
 from prettytable import PrettyTable
 
 from mite.datapools import SingleRunDataPoolWrapper
@@ -162,7 +163,6 @@ def test_scenarios(test_name, opts, scenarios, config_manager):
         opts.get("--max-errors-threshold")
     )
 
-    
     if opts.get("--max-response-time-threshold") != "0":
         max_response_time = http_stats_output._resp_time_max * 1000
         if max_response_time > int(opts["--max-response-time-threshold"]):
@@ -179,7 +179,9 @@ def test_scenarios(test_name, opts, scenarios, config_manager):
         resp_time_stddev = http_stats_output.resp_time_standard_deviation * 1000
         if resp_time_stddev > int(opts["--standard-deviation-response-time-threshold"]):
             has_error = True
-            logging.error("Response time standard deviation exceeded: %sms", resp_time_stddev)
+            logging.error(
+                "Response time standard deviation exceeded: %sms", resp_time_stddev
+            )
 
     if opts.get("--standard-deviation-req-sec-threshold") != "0":
         req_sec_stddev = http_stats_output.req_sec_standard_deviation
@@ -189,7 +191,6 @@ def test_scenarios(test_name, opts, scenarios, config_manager):
 
     if opts.get("--report"):
         benchmark_report(http_stats_output)
-   
 
     # Ensure any open files get closed
     del receiver._raw_listeners
@@ -209,28 +210,38 @@ def human_readable_bytes(size):
 def benchmark_report(http_stats_output):
     table = PrettyTable()
     table.field_names = ["Metric", "Avg", "Min", "Max", "Std Dev", "+/- Std Dev"]
-    number_format = lambda number: f"{number / 1000:.2f}K" if number >= 1000 else f"{number:.2f}"
+    number_format = (
+        lambda number: f"{number / 1000:.2f}K" if number >= 1000 else f"{number:.2f}"
+    )
 
-    table.add_row([
-    "Latency",
-    f"{http_stats_output.mean_resp_time * 1000:.2f}ms",
-    f"{http_stats_output._resp_time_min * 1000:.2f}ms",
-    f"{http_stats_output._resp_time_max * 1000:.2f}ms",
-    f"{http_stats_output.resp_time_standard_deviation * 1000:.2f}ms",
-    f"{http_stats_output.resp_time_within_standard_deviation:.2f}%"])
-    
-    table.add_row([
-    "Req/Sec",
-    number_format(http_stats_output.req_sec_mean),
-    number_format(http_stats_output._req_sec_min),
-    number_format(http_stats_output._req_sec_max),
-    number_format(http_stats_output.req_sec_standard_deviation),
-    f"{http_stats_output.req_sec_within_standard_deviation:.2f}%"])
+    table.add_row(
+        [
+            "Latency",
+            f"{http_stats_output.mean_resp_time * 1000:.2f}ms",
+            f"{http_stats_output._resp_time_min * 1000:.2f}ms",
+            f"{http_stats_output._resp_time_max * 1000:.2f}ms",
+            f"{http_stats_output.resp_time_standard_deviation * 1000:.2f}ms",
+            f"{http_stats_output.resp_time_within_standard_deviation:.2f}%",
+        ]
+    )
+
+    table.add_row(
+        [
+            "Req/Sec",
+            number_format(http_stats_output.req_sec_mean),
+            number_format(http_stats_output._req_sec_min),
+            number_format(http_stats_output._req_sec_max),
+            number_format(http_stats_output.req_sec_standard_deviation),
+            f"{http_stats_output.req_sec_within_standard_deviation:.2f}%",
+        ]
+    )
 
     table.align["Metric"] = "l"
     data_transfer, data_unit = human_readable_bytes(http_stats_output._data_transferred)
     print(table)
-    print(f"{http_stats_output._req_total} requests in {http_stats_output._scenarios_completed_time - http_stats_output._init_time:.2f}s, {data_transfer:.2f} {data_unit} data transferred")
+    print(
+        f"{http_stats_output._req_total} requests in {http_stats_output._scenarios_completed_time - http_stats_output._init_time:.2f}s, {data_transfer:.2f} {data_unit} data transferred"
+    )
 
 
 def scenario_test_cmd(opts):

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -196,7 +196,7 @@ class GenericStatsOutput:
             return 0
         variance = []
         for req_sec in self._req_sec_store:
-            variance.append(math.sqrt(req_sec-self.req_sec_mean)**2)
+            variance.append(math.sqrt((req_sec-self.req_sec_mean)**2))
         std_deviation = sum(variance) / len(self._req_sec_store)
         return std_deviation
     

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -180,16 +180,6 @@ class GenericStatsOutput:
     def req_sec_mean(self):
         return self._req_total / (self._scenarios_completed_time - self._init_time)
     
-    # @property
-    # def stats_within_standard_deviation(self, value_store, stddev, mean):
-    #     upper_limit = mean + stddev
-    #     lower_limit = mean - stddev
-    #     count = 0
-    #     for value in value_store:
-    #         if (upper_limit >= value) or (value >= lower_limit):
-    #             count = count+1
-    #     return (count / len(value_store)) * 100
-    
     @property
     def resp_time_standard_deviation(self):
         if not self._resp_time_mean_store:
@@ -198,8 +188,6 @@ class GenericStatsOutput:
         for resp_time in self._resp_time_recent:
             variance.append(math.sqrt((resp_time-self.mean_resp_time)**2))
         std_deviation = sum(variance) / len(self._resp_time_recent)
-        # resp_time_within_stddev = self.resp_time_within_standard_deviation
-        # del self._resp_time_recent[:]
         return std_deviation
     
     @property
@@ -210,8 +198,6 @@ class GenericStatsOutput:
         for req_sec in self._req_sec_store:
             variance.append(math.sqrt(req_sec-self.req_sec_mean)**2)
         std_deviation = sum(variance) / len(self._req_sec_store)
-        # req_sec_within_stddev = self.req_sec_within_standard_deviation
-        # del self._req_sec_store[:]
         return std_deviation
     
     @property

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -262,8 +262,10 @@ class GenericStatsOutput:
     def resp_time_within_standard_deviation(self):
         if not self._resp_time_store:
             return 0
-        return statistics.mean(((self.resp_time_array <= (self.mean_resp_time + self.resp_time_standard_deviation)) & (self.resp_time_array >= (self.mean_resp_time - self.resp_time_standard_deviation)))) * 100
-    
+        # return statistics.mean(((self._resp_time_store <= (self.mean_resp_time + self.resp_time_standard_deviation)) & (self._resp_time_store >= (self.mean_resp_time - self.resp_time_standard_deviation)))) * 100
+        return sum((self.mean_resp_time - self.resp_time_standard_deviation) <= x <= (self.mean_resp_time + self.resp_time_standard_deviation) 
+                   for x in self._resp_time_store) / len(self._resp_time_store) * 100
+
     # @property
     # def req_sec_within_standard_deviation(self):
     #     upper_limit = self.req_sec_mean + self.req_sec_standard_deviation
@@ -281,7 +283,9 @@ class GenericStatsOutput:
     def req_sec_within_standard_deviation(self):
         if self._req_total == 0:
             return 0
-        return statistics.mean(((self.req_sec_array <= (self.req_sec_mean + self.req_sec_standard_deviation)) & (self.req_sec_array >= (self.req_sec_mean - self.req_sec_standard_deviation)))) * 100
+        # return statistics.mean(((self._req_sec_store <= (self.req_sec_mean + self.req_sec_standard_deviation)) & (self._req_sec_store >= (self.req_sec_mean - self.req_sec_standard_deviation)))) * 100
+        return sum((self.req_sec_mean - self.req_sec_standard_deviation) <= x <= (self.req_sec_mean + self.req_sec_standard_deviation) 
+                   for x in self._req_sec_store) / len(self._req_sec_store) * 100
 
 class HttpStatsOutput(GenericStatsOutput):
     message_types = {

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -180,16 +180,26 @@ class GenericStatsOutput:
     def req_sec_mean(self):
         return self._req_total / (self._scenarios_completed_time - self._init_time)
     
+    # @property
+    # def stats_within_standard_deviation(self, value_store, stddev, mean):
+    #     upper_limit = mean + stddev
+    #     lower_limit = mean - stddev
+    #     count = 0
+    #     for value in value_store:
+    #         if (upper_limit >= value) or (value >= lower_limit):
+    #             count = count+1
+    #     return (count / len(value_store)) * 100
+    
     @property
     def resp_time_standard_deviation(self):
         if not self._resp_time_mean_store:
             return 0
         variance = []
-        mean_resp_time = sum(self._resp_time_mean_store) / len(self._resp_time_mean_store)
         for resp_time in self._resp_time_recent:
-            variance.append(math.sqrt((resp_time-mean_resp_time)**2))
+            variance.append(math.sqrt((resp_time-self.mean_resp_time)**2))
         std_deviation = sum(variance) / len(self._resp_time_recent)
-        del self._resp_time_recent[:]
+        # resp_time_within_stddev = self.resp_time_within_standard_deviation
+        # del self._resp_time_recent[:]
         return std_deviation
     
     @property
@@ -197,14 +207,36 @@ class GenericStatsOutput:
         if self._req_total == 0:
             return 0
         variance = []
-        mean_req_sec = self._req_total / (self._scenarios_completed_time - self._init_time)
         for req_sec in self._req_sec_store:
-            variance.append(math.sqrt(req_sec-mean_req_sec)**2)
+            variance.append(math.sqrt(req_sec-self.req_sec_mean)**2)
         std_deviation = sum(variance) / len(self._req_sec_store)
-        del self._req_sec_store[:]
+        # req_sec_within_stddev = self.req_sec_within_standard_deviation
+        # del self._req_sec_store[:]
         return std_deviation
-
-
+    
+    @property
+    def resp_time_within_standard_deviation(self):
+        upper_limit = self.mean_resp_time + self.resp_time_standard_deviation
+        lower_limit = self.mean_resp_time - self.resp_time_standard_deviation
+        count = 0
+        for resp_time in self._resp_time_recent:
+            if (upper_limit >= resp_time) and (resp_time >= lower_limit):
+                count = count +1
+        stats_percentage = count / len(self._resp_time_recent) * 100
+        del self._resp_time_recent[:]
+        return stats_percentage
+    
+    @property
+    def req_sec_within_standard_deviation(self):
+        upper_limit = self.req_sec_mean + self.req_sec_standard_deviation
+        lower_limit = self.req_sec_mean - self.req_sec_standard_deviation
+        count = 0
+        for req_sec in self._req_sec_store:
+            if (upper_limit >= req_sec) and (req_sec >= lower_limit):
+                count = count+1
+        stats_percetage = count / len(self._req_sec_store) * 100
+        del self._req_sec_store[:]
+        return stats_percetage
 
 class HttpStatsOutput(GenericStatsOutput):
     message_types = {

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -193,30 +193,28 @@ class GenericStatsOutput:
             return 0
         return statistics.stdev(self._req_sec_store)
 
+    # Calculating percentage of resp times that lie within deviation limits (Mean +/- Standard deviation)
     @property
     def resp_time_within_standard_deviation(self):
         if not self._resp_time_store:
             return 0
         return (
             sum(
-                (self.mean_resp_time - self.resp_time_standard_deviation)
-                <= x
-                <= (self.mean_resp_time + self.resp_time_standard_deviation)
+                abs(x - self.mean_resp_time) < self.resp_time_standard_deviation
                 for x in self._resp_time_store
             )
             / len(self._resp_time_store)
             * 100
         )
 
+    # Calculating percentage of req/sec that lie within deviation limits (Mean +/- Standard deviation)
     @property
     def req_sec_within_standard_deviation(self):
         if self._req_total == 0:
             return 0
         return (
             sum(
-                (self.req_sec_mean - self.req_sec_standard_deviation)
-                <= x
-                <= (self.req_sec_mean + self.req_sec_standard_deviation)
+                abs(x - self.req_sec_mean) < self.req_sec_standard_deviation
                 for x in self._req_sec_store
             )
             / len(self._req_sec_store)

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -1,8 +1,8 @@
 import logging
 import math
+import statistics
 import time
 from collections import defaultdict
-import statistics
 
 
 class MsgOutput:
@@ -127,7 +127,9 @@ class GenericStatsOutput:
                 if self._resp_time_min == 0:
                     self._resp_time_min = self.min_resp_time_recent
                 else:
-                    self._resp_time_min = min(self.min_resp_time_recent, self._resp_time_min)
+                    self._resp_time_min = min(
+                        self.min_resp_time_recent, self._resp_time_min
+                    )
 
                 self._resp_time_max = max(self.max_resp_time_recent, self._resp_time_max)
 
@@ -154,7 +156,7 @@ class GenericStatsOutput:
             if self._journey_logging:
                 journey_name = message.get("journey")
                 self._error_journeys[journey_name] += 1
-    
+
     @property
     def mean_resp_time(self):
         if not self._resp_time_store:
@@ -178,32 +180,49 @@ class GenericStatsOutput:
         if self._req_total == 0:
             return 0
         return statistics.fmean(self._req_sec_store)
-    
+
     @property
     def resp_time_standard_deviation(self):
         if not self._resp_time_store:
             return 0
         return statistics.stdev(self._resp_time_store)
-    
+
     @property
     def req_sec_standard_deviation(self):
         if self._req_total == 0:
             return 0
         return statistics.stdev(self._req_sec_store)
-    
+
     @property
     def resp_time_within_standard_deviation(self):
         if not self._resp_time_store:
             return 0
-        return sum((self.mean_resp_time - self.resp_time_standard_deviation) <= x <= (self.mean_resp_time + self.resp_time_standard_deviation) 
-                   for x in self._resp_time_store) / len(self._resp_time_store) * 100
+        return (
+            sum(
+                (self.mean_resp_time - self.resp_time_standard_deviation)
+                <= x
+                <= (self.mean_resp_time + self.resp_time_standard_deviation)
+                for x in self._resp_time_store
+            )
+            / len(self._resp_time_store)
+            * 100
+        )
 
     @property
     def req_sec_within_standard_deviation(self):
         if self._req_total == 0:
             return 0
-        return sum((self.req_sec_mean - self.req_sec_standard_deviation) <= x <= (self.req_sec_mean + self.req_sec_standard_deviation) 
-                   for x in self._req_sec_store) / len(self._req_sec_store) * 100
+        return (
+            sum(
+                (self.req_sec_mean - self.req_sec_standard_deviation)
+                <= x
+                <= (self.req_sec_mean + self.req_sec_standard_deviation)
+                for x in self._req_sec_store
+            )
+            / len(self._req_sec_store)
+            * 100
+        )
+
 
 class HttpStatsOutput(GenericStatsOutput):
     message_types = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     flask
     msgpack
     nanomsg
+    prettytable
     pyzmq
     selenium<4
     uvloop


### PR DESCRIPTION
#### What is the change?

Add stddev and +/- std dev to benchmark report. 

Added new flags `--standard-deviation-response-time-threshold` and `--standard-deviation-req-sec-threshold` 

Updated mean to use statistics library and to calculate values from overall response time instead of calculating from resp_time_mean_store which has the collection of mean of response time from each instance. 
Same logic is applied for req per sec. Updated the format of report at the end. Now the report looks like this 

![Screenshot 2024-09-04 at 2 15 54 PM](https://github.com/user-attachments/assets/6f715f32-cad1-4789-88a2-13b958a69d7f)



#### Does this change require a version increment:

- [ ] Major
- [x] Minor
- [ ] Patch
