### PR TITLE
Update of mite_kafka module 

### DIFF
--- a/mite_kafka/__init__.py
+++ b/mite_kafka/__init__.py
@@ -52,15 +52,14 @@ class KafkaConsumer:
 
     async def start(self, *args, **kwargs):
         self._consumer = AIOKafkaConsumer(*args, **kwargs)
-        await self._consumer.start()
         return self._consumer
 
     async def get_msg(self):
         return self._consumer
 
-    async def get_message(self, consumer, *topics, **kwargs):
-        breakpoint()
-        async for msg in consumer:
+    async def get_messages(self):
+        await self._consumer.start()
+        async for msg in self._consumer:
             return msg
 
     async def stop(self):

--- a/mite_kafka/__init__.py
+++ b/mite_kafka/__init__.py
@@ -22,7 +22,7 @@ class KafkaProducer:
         self._loop = asyncio.get_event_loop()
         self._producer = None
 
-    def _uninstall(self, ctx):
+    def _remove_producer(self, ctx):
         del ctx.kafka_producer
 
     async def start(self, *args, **kwargs):
@@ -41,7 +41,7 @@ class KafkaConsumer:
         self._loop = asyncio.get_event_loop()
         self._consumer = None
 
-    def _uninstall(self, ctx):
+    def _remove_consumer(self, ctx):
         del ctx.kafka_consumer
 
     async def start(self, *args, **kwargs):
@@ -70,8 +70,8 @@ async def _kafka_context_manager(ctx):
         print(e)
         raise KafkaError(e)
     finally:
-        ctx.kafka_producer._uninstall(ctx)
-        ctx.kafka_consumer._uninstall(ctx)
+        ctx.kafka_producer._remove_producer(ctx)
+        ctx.kafka_consumer._remove_consumer(ctx)
 
 
 def mite_kafka(func):

--- a/mite_kafka/__init__.py
+++ b/mite_kafka/__init__.py
@@ -22,11 +22,11 @@ class KafkaProducer:
     def _remove_producer(self, ctx):
         del ctx.kafka_producer
 
-    async def start(self, *args, **kwargs):
+    async def create(self, *args, **kwargs):
         self._producer = AIOKafkaProducer(*args, **kwargs)
-        await self._producer.start()
 
     async def send_and_wait(self, topic, key=None, value=None, **kwargs):
+        await self._producer.start()
         await self._producer.send_and_wait(topic, key=key, value=value, **kwargs)
 
     async def stop(self):
@@ -42,7 +42,7 @@ class KafkaConsumer:
     def _remove_consumer(self, ctx):
         del ctx.kafka_consumer
 
-    async def start(self, *args, **kwargs):
+    async def create(self, *args, **kwargs):
         self._consumer = AIOKafkaConsumer(*args, **kwargs)
         self._topics = args
 

--- a/mite_kafka/__init__.py
+++ b/mite_kafka/__init__.py
@@ -1,12 +1,9 @@
 import asyncio
-import logging
 from contextlib import asynccontextmanager
 
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
 
 from mite.exceptions import MiteError
-
-logger = logging.getLogger(__name__)
 
 
 class KafkaError(MiteError):

--- a/mite_kafka/__init__.py
+++ b/mite_kafka/__init__.py
@@ -22,10 +22,7 @@ class KafkaProducer:
         self._loop = asyncio.get_event_loop()
         self._producer = None
 
-    def install(self, ctx):
-        ctx.kafka_producer = self
-
-    def uninstall(self, ctx):
+    def _uninstall(self, ctx):
         del ctx.kafka_producer
 
     async def start(self, *args, **kwargs):
@@ -44,10 +41,7 @@ class KafkaConsumer:
         self._loop = asyncio.get_event_loop()
         self._consumer = None
 
-    def install(self, ctx):
-        ctx.kafka_consumer = self
-
-    def uninstall(self, ctx):
+    def _uninstall(self, ctx):
         del ctx.kafka_consumer
 
     async def start(self, *args, **kwargs):
@@ -69,17 +63,15 @@ class KafkaConsumer:
 @asynccontextmanager
 async def _kafka_context_manager(ctx):
     ctx.kafka_producer = KafkaProducer()
-    ctx.kafka_producer.install(ctx)
     ctx.kafka_consumer = KafkaConsumer()
-    ctx.kafka_consumer.install(ctx)
     try:
         yield
     except Exception as e:
         print(e)
         raise KafkaError(e)
     finally:
-        ctx.kafka_producer.uninstall(ctx)
-        ctx.kafka_consumer.uninstall(ctx)
+        ctx.kafka_producer._uninstall(ctx)
+        ctx.kafka_consumer._uninstall(ctx)
 
 
 def mite_kafka(func):

--- a/mite_kafka/__init__.py
+++ b/mite_kafka/__init__.py
@@ -18,7 +18,7 @@ class KafkaContext:
 
 
 class KafkaProducer:
-    def __init__(self):
+    def __init__(self, ctx):
         self._loop = asyncio.get_event_loop()
         self._producer = None
 
@@ -37,19 +37,17 @@ class KafkaProducer:
 
 
 class KafkaConsumer:
-    def __init__(self):
+    def __init__(self, ctx):
         self._loop = asyncio.get_event_loop()
         self._consumer = None
+        self._topics = None
 
     def _remove_consumer(self, ctx):
         del ctx.kafka_consumer
 
     async def start(self, *args, **kwargs):
         self._consumer = AIOKafkaConsumer(*args, **kwargs)
-        return self._consumer
-
-    async def get_msg(self):
-        return self._consumer
+        self._topics = args
 
     async def get_messages(self):
         await self._consumer.start()
@@ -62,8 +60,8 @@ class KafkaConsumer:
 
 @asynccontextmanager
 async def _kafka_context_manager(ctx):
-    ctx.kafka_producer = KafkaProducer()
-    ctx.kafka_consumer = KafkaConsumer()
+    ctx.kafka_producer = KafkaProducer(ctx)
+    ctx.kafka_consumer = KafkaConsumer(ctx)
     try:
         yield
     except Exception as e:

--- a/test/test_mite_kafka.py
+++ b/test/test_mite_kafka.py
@@ -12,7 +12,8 @@ async def test_mite_kafka_decorator():
 
     @mite_kafka
     async def dummy_journey(ctx):
-        assert ctx.kafka is not None
+        assert ctx.kafka_producer is not None
+        assert ctx.kafka_consumer is not None
 
     await dummy_journey(context)
 
@@ -34,15 +35,15 @@ async def test_mite_kafka_decorator_uninstall():
 async def test_create_producer():
     # Create a mock for AIOKafkaProducer
     producer_mock = MagicMock()
+    context = MockContext()
 
     # Patch AIOKafkaProducer to return the mock
     with patch("aiokafka.producer.AIOKafkaProducer", new_callable=producer_mock):
         # Create an instance of _KafkaWrapper
-        kafka_wrapper = KafkaProducer()
+        kafka_wrapper = KafkaProducer(context)
         # Call the create_producer method
-        await kafka_wrapper.start(
-            bootstrap_servers="broker_url"
-        )  # Pass the broker URL as a keyword argument
+        await kafka_wrapper.create(bootstrap_servers="broker_url")
+        # Pass the broker URL as a keyword argument
         # Assert that the AIOKafkaProducer class was called with the expected arguments
         producer_mock.assert_called_once_with()
 
@@ -51,13 +52,14 @@ async def test_create_producer():
 async def test_create_consumer():
     # Create a mock for AIOKafkaConsumer
     consumer_mock = MagicMock()
+    context = MockContext()
 
     # Patch AIOKafkaConsumer to return the mock
     with patch("aiokafka.consumer.AIOKafkaConsumer", new_callable=consumer_mock):
         # Create an instance of _KafkaWrapper
-        kafka_wrapper = KafkaConsumer()
+        kafka_wrapper = KafkaConsumer(context)
         # Call the create_consumer method
-        await kafka_wrapper.start(
+        await kafka_wrapper.create(
             bootstrap_servers="broker_url"
         )  # Pass the broker URL as a keyword argument
         # Assert that the AIOKafkaConsumer class was called with the expected arguments

--- a/test/test_mite_kafka.py
+++ b/test/test_mite_kafka.py
@@ -1,11 +1,9 @@
-import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
-from mite_kafka import _KafkaWrapper, mite_kafka
 from mocks.mock_context import MockContext
-import aiokafka
 
+from mite_kafka import KafkaConsumer, KafkaProducer, mite_kafka
 
 
 @pytest.mark.asyncio
@@ -17,6 +15,7 @@ async def test_mite_kafka_decorator():
         assert ctx.kafka is not None
 
     await dummy_journey(context)
+
 
 @pytest.mark.asyncio
 async def test_mite_kafka_decorator_uninstall():
@@ -30,19 +29,23 @@ async def test_mite_kafka_decorator_uninstall():
 
     assert getattr(context, "kafka", None) is None
 
+
 @pytest.mark.asyncio
 async def test_create_producer():
     # Create a mock for AIOKafkaProducer
     producer_mock = MagicMock()
 
     # Patch AIOKafkaProducer to return the mock
-    with patch('aiokafka.producer.AIOKafkaProducer', new_callable=producer_mock):
+    with patch("aiokafka.producer.AIOKafkaProducer", new_callable=producer_mock):
         # Create an instance of _KafkaWrapper
-        kafka_wrapper = _KafkaWrapper()
+        kafka_wrapper = KafkaProducer()
         # Call the create_producer method
-        await kafka_wrapper.create_producer(bootstrap_servers='broker_url')  # Pass the broker URL as a keyword argument
+        await kafka_wrapper.start(
+            bootstrap_servers="broker_url"
+        )  # Pass the broker URL as a keyword argument
         # Assert that the AIOKafkaProducer class was called with the expected arguments
         producer_mock.assert_called_once_with()
+
 
 @pytest.mark.asyncio
 async def test_create_consumer():
@@ -50,11 +53,12 @@ async def test_create_consumer():
     consumer_mock = MagicMock()
 
     # Patch AIOKafkaConsumer to return the mock
-    with patch('aiokafka.consumer.AIOKafkaConsumer', new_callable=consumer_mock):
+    with patch("aiokafka.consumer.AIOKafkaConsumer", new_callable=consumer_mock):
         # Create an instance of _KafkaWrapper
-        kafka_wrapper = _KafkaWrapper()
+        kafka_wrapper = KafkaConsumer()
         # Call the create_consumer method
-        await kafka_wrapper.create_consumer(bootstrap_servers='broker_url')  # Pass the broker URL as a keyword argument
+        await kafka_wrapper.start(
+            bootstrap_servers="broker_url"
+        )  # Pass the broker URL as a keyword argument
         # Assert that the AIOKafkaConsumer class was called with the expected arguments
         consumer_mock.assert_called_once_with()
-        


### PR DESCRIPTION
#### What is the change?
Update of the kafka module:
- Clean up of unused libraries
- Separation of Kafka producer and Consumer class. They still share the single context manager but now it is possible to create different object between producer and consumer
- Some methods have been update in order to use the objection mention above directly. An example is `producer = ctx.kafka_producer` and then being able to use `producer.start()` instead of `ctx.kafka.start_producer(producer)`

#### Does this change require a version increment:

- [ ] Major
- [x] Minor
- [ ] Patch
