### PR TITLE
Dynamic percentile latency report

### DIFF
--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -97,6 +97,8 @@ Options:
     --mean-response-time-threshold=THRESHOLD                Set the mean response time accepted before setting exit status to 1 [default: 0]
     --standard-deviation-response-time-threshold=THRESHOLD  Set the response time standard deviation accepted before setting exit status to 1 [default: 0]
     --standard-deviation-req-sec-threshold=THRESHOLD        Set the request per second standard deviation accepted before setting exit status to 1 [default: 0]
+    --benchmark-percentiles=NEW_VALUE                       Percentiles can be set to a list of integers separated by commas, list defaults to [50, 73, 90, 99]
+    --benchmark-percentiles-bucket-size=NEW_VALUE           Percentiles bucket size [default: 100]
 """
 import asyncio
 import logging

--- a/mite/__main__.py
+++ b/mite/__main__.py
@@ -97,8 +97,7 @@ Options:
     --mean-response-time-threshold=THRESHOLD                Set the mean response time accepted before setting exit status to 1 [default: 0]
     --standard-deviation-response-time-threshold=THRESHOLD  Set the response time standard deviation accepted before setting exit status to 1 [default: 0]
     --standard-deviation-req-sec-threshold=THRESHOLD        Set the request per second standard deviation accepted before setting exit status to 1 [default: 0]
-    --benchmark-percentiles=NEW_VALUE                       Percentiles can be set to a list of integers separated by commas, list defaults to [50, 73, 90, 99]
-    --benchmark-percentiles-bucket-size=NEW_VALUE           Percentiles bucket size [default: 100]
+    --benchmark-percentiles=NEW_VALUE                       Percentiles(int):threshold(int in milliseconds) pairs separated by commas [default: 50:0,90:0,98:0,99:0]
 """
 import asyncio
 import logging

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -218,7 +218,7 @@ def human_readable_bytes(size):
 
 
 def time_unit_format(number):
-    return f"{number * 1000:.2f}ms" if number >= 0.001 else f"{number:.2f}s"
+    return f"{number * 1000:.2f}ms" if number < 1 else f"{number:.3f}s"
 
 
 def colorise_result(result, threshold):

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -217,17 +217,22 @@ def human_readable_bytes(size):
     return size, "PB"
 
 
+def time_unit_format(number):
+    return f"{number * 1000:.2f}ms" if number >= 0.001 else f"{number:.2f}s"
+
+
 def colorise_result(result, threshold):
-    result_ms = result * 1000
+    formatted_result = time_unit_format(result)
     if threshold != 0:
+        result_ms = result * 1000
         if result_ms >= threshold:
-            return f"\033[91m{result_ms:.2f}ms\033[0m"  # red
+            return f"\033[91m{formatted_result}\033[0m"  # red
         else:
-            return f"\033[92m{result_ms:.2f}ms\033[0m"  # green
-    return f"{result_ms:.2f}ms"
+            return f"\033[92m{formatted_result}\033[0m"  # green
+    return formatted_result
 
 
-def benchmark_report(http_stats_output, has_error=False):
+def benchmark_report(http_stats_output):
     perctile_thresh_results_list = http_stats_output.percentiles_list_resp_time_store
 
     percentiles_headers = [
@@ -241,10 +246,10 @@ def benchmark_report(http_stats_output, has_error=False):
     latency_table.add_row(
         [
             "Latency",
-            f"{http_stats_output.mean_resp_time * 1000:.2f}ms",
-            f"{http_stats_output._resp_time_min * 1000:.2f}ms",
-            f"{http_stats_output._resp_time_max * 1000:.2f}ms",
-            f"{http_stats_output.resp_time_standard_deviation * 1000:.2f}ms",
+            time_unit_format(http_stats_output.mean_resp_time),
+            time_unit_format(http_stats_output._resp_time_min),
+            time_unit_format(http_stats_output._resp_time_max),
+            time_unit_format(http_stats_output.resp_time_standard_deviation),
             f"{http_stats_output.resp_time_within_standard_deviation:.2f}%",
             *[
                 colorise_result(result, threshold)

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -217,6 +217,16 @@ def human_readable_bytes(size):
     return size, "PB"
 
 
+def colorise_result(result, threshold):
+    result_ms = result * 1000
+    if threshold != 0:
+        if result_ms >= threshold:
+            return f"\033[91m{result_ms:.2f}ms\033[0m"  # red
+        else:
+            return f"\033[92m{result_ms:.2f}ms\033[0m"  # green
+    return f"{result_ms:.2f}ms"
+
+
 def benchmark_report(http_stats_output, has_error=False):
     perctile_thresh_results_list = http_stats_output.percentiles_list_resp_time_store
 
@@ -227,6 +237,7 @@ def benchmark_report(http_stats_output, has_error=False):
 
     latency_table = PrettyTable()
     latency_table.field_names = standard_headers + percentiles_headers
+
     latency_table.add_row(
         [
             "Latency",
@@ -236,11 +247,7 @@ def benchmark_report(http_stats_output, has_error=False):
             f"{http_stats_output.resp_time_standard_deviation * 1000:.2f}ms",
             f"{http_stats_output.resp_time_within_standard_deviation:.2f}%",
             *[
-                f"\033[91m{result * 1000:.2f}ms\033[0m"
-                if threshold != 0 and result * 1000 >= threshold
-                else f"\033[92m{result * 1000:.2f}ms\033[0m"
-                if threshold != 0
-                else f"{result * 1000:.2f}ms"
+                colorise_result(result, threshold)
                 for _, threshold, result in perctile_thresh_results_list
             ],
         ],

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -209,10 +209,11 @@ def human_readable_bytes(size):
 
 def benchmark_report(http_stats_output):
     table = PrettyTable()
-    table.field_names = ["Metric", "Avg", "Min", "Max", "Std Dev", "+/- Std Dev"]
-    number_format = (
-        lambda number: f"{number / 1000:.2f}K" if number >= 1000 else f"{number:.2f}"
-    )
+    percentiles_list, _ = http_stats_output._percentiles_with_thresholds()
+    percentiles_headers = [f"{int(p)} %tile" for p in percentiles_list]
+    standard_headers = ["Metric", "Avg", "Min", "Max", "Std Dev", "+/- Std Dev"]
+
+    table.field_names = standard_headers + percentiles_headers
 
     table.add_row(
         [
@@ -222,19 +223,26 @@ def benchmark_report(http_stats_output):
             f"{http_stats_output._resp_time_max * 1000:.2f}ms",
             f"{http_stats_output.resp_time_standard_deviation * 1000:.2f}ms",
             f"{http_stats_output.resp_time_within_standard_deviation:.2f}%",
+            *[
+                f"{x * 1000:.2f}ms"
+                for x in http_stats_output.percentiles_list_resp_time_store
+            ],
         ]
     )
 
-    table.add_row(
-        [
-            "Req/Sec",
-            number_format(http_stats_output.req_sec_mean),
-            number_format(http_stats_output._req_sec_min),
-            number_format(http_stats_output._req_sec_max),
-            number_format(http_stats_output.req_sec_standard_deviation),
-            f"{http_stats_output.req_sec_within_standard_deviation:.2f}%",
-        ]
-    )
+    # number_format = (
+    #     lambda number: f"{number / 1000:.2f}K" if number >= 1000 else f"{number:.2f}"
+    # )
+    # table.add_row(
+    #     [
+    #         "Req/Sec",
+    #         number_format(http_stats_output.req_sec_mean),
+    #         number_format(http_stats_output._req_sec_min),
+    #         number_format(http_stats_output._req_sec_max),
+    #         number_format(http_stats_output.req_sec_standard_deviation),
+    #         f"{http_stats_output.req_sec_within_standard_deviation:.2f}%",
+    #     ]
+    # )
 
     table.align["Metric"] = "l"
     data_transfer, data_unit = human_readable_bytes(http_stats_output._data_transferred)

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -128,6 +128,10 @@ async def controller_report(controller, receiver):
         controller.report(receiver.recieve)
 
 
+def time_unit_format(number):
+    return f"{number * 1000:.2f}ms" if number < 1 else f"{number:.3f}s"
+
+
 def test_scenarios(test_name, opts, scenarios, config_manager):
     scenario_manager = _create_scenario_manager(opts)
     for journey_spec, datapool, volumemodel in scenarios:
@@ -199,7 +203,7 @@ def test_scenarios(test_name, opts, scenarios, config_manager):
             if threshold != 0 and result * 1000 >= threshold:
                 has_error = True
                 logging.error(
-                    f"Response time at {percentile}th percentile exceeded {threshold}ms: {result * 1000:.2f}ms"
+                    f"Response time at {percentile}th percentile exceeded {threshold}ms: {time_unit_format(result)}"
                 )
 
     # Ensure any open files get closed
@@ -215,10 +219,6 @@ def human_readable_bytes(size):
             return size, unit
         size /= 1024.0
     return size, "PB"
-
-
-def time_unit_format(number):
-    return f"{number * 1000:.2f}ms" if number < 1 else f"{number:.3f}s"
 
 
 def colorise_result(result, threshold):

--- a/mite/cli/test.py
+++ b/mite/cli/test.py
@@ -208,14 +208,13 @@ def human_readable_bytes(size):
 
 
 def benchmark_report(http_stats_output):
-    table = PrettyTable()
+    latency_table = PrettyTable()
     percentiles_list, _ = http_stats_output._percentiles_with_thresholds()
     percentiles_headers = [f"{int(p)} %tile" for p in percentiles_list]
-    standard_headers = ["Metric", "Avg", "Min", "Max", "Std Dev", "+/- Std Dev"]
+    standard_headers = ["", "Avg", "Min", "Max", "Std Dev", "+/- Std Dev"]
 
-    table.field_names = standard_headers + percentiles_headers
-
-    table.add_row(
+    latency_table.field_names = standard_headers + percentiles_headers
+    latency_table.add_row(
         [
             "Latency",
             f"{http_stats_output.mean_resp_time * 1000:.2f}ms",
@@ -230,25 +229,30 @@ def benchmark_report(http_stats_output):
         ]
     )
 
-    # number_format = (
-    #     lambda number: f"{number / 1000:.2f}K" if number >= 1000 else f"{number:.2f}"
-    # )
-    # table.add_row(
-    #     [
-    #         "Req/Sec",
-    #         number_format(http_stats_output.req_sec_mean),
-    #         number_format(http_stats_output._req_sec_min),
-    #         number_format(http_stats_output._req_sec_max),
-    #         number_format(http_stats_output.req_sec_standard_deviation),
-    #         f"{http_stats_output.req_sec_within_standard_deviation:.2f}%",
-    #     ]
-    # )
+    requests_table = PrettyTable()
+    requests_table.field_names = standard_headers
+    number_format = (
+        lambda number: f"{number / 1000:.2f}K" if number >= 1000 else f"{number:.2f}"
+    )
+    requests_table.add_row(
+        [
+            "Req/Sec",
+            number_format(http_stats_output.req_sec_mean),
+            number_format(http_stats_output._req_sec_min),
+            number_format(http_stats_output._req_sec_max),
+            number_format(http_stats_output.req_sec_standard_deviation),
+            f"{http_stats_output.req_sec_within_standard_deviation:.2f}%",
+        ]
+    )
 
-    table.align["Metric"] = "l"
     data_transfer, data_unit = human_readable_bytes(http_stats_output._data_transferred)
-    print(table)
+    print("\n" + "=" * 20 + " MITE Benchmark Report " + "=" * 20)
+    print(latency_table, end="\n")
+    # print(requests_table, end="\n")
+    print("\n" + "=" * 27 + " Summary " + "=" * 27)
     print(
-        f"{http_stats_output._req_total} requests in {http_stats_output._scenarios_completed_time - http_stats_output._init_time:.2f}s, {data_transfer:.2f} {data_unit} data transferred"
+        f"{http_stats_output._req_total} requests in {http_stats_output._scenarios_completed_time - http_stats_output._init_time:.2f}s, {data_transfer:.2f} {data_unit} data transferred",
+        end="\n\n",
     )
 
 

--- a/mite/config.py
+++ b/mite/config.py
@@ -46,10 +46,10 @@ def default_config_loader():
     for name, value in os.environ.items():
         if name.startswith("MITE_CONF_"):
             key_name = name[10:]
-            logger.info(f'Setting config "{key_name}" from environment variable')
+            logger.debug(f'Setting config "{key_name}" from environment variable')
             result[key_name] = value
         if name.startswith("MITE_EVAL_CONF_"):
             key_name = name[15:]
-            logger.info(f'Setting config "{key_name}" by eval\'ing environment variable')
+            logger.debug(f'Setting config "{key_name}" by eval\'ing environment variable')
             result[key_name] = eval(value)
     return result

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -64,12 +64,7 @@ class GenericStatsOutput:
         self._data_transferred = 0
         self._standard_deviation = 0
         self._error_journeys = defaultdict(int)
-        self._benchmark_percentiles = (
-            opts.get("--benchmark-percentiles") or "53:50,90:300,99:500"
-        )
-        self._benchmark_percentiles_bucket_size = (
-            opts.get("--benchmark-percentiles-bucket-size") or 100
-        )
+        self._benchmark_percentiles = opts.get("--benchmark-percentiles")
 
     def _pct(self, percentile):
         """Percentile calculation with linear interpolation.
@@ -176,10 +171,7 @@ class GenericStatsOutput:
         if not self._resp_time_store:
             return 0
         return [
-            statistics.quantiles(
-                self._resp_time_store, n=int(self._benchmark_percentiles_bucket_size)
-            )[p - 1]
-            for p in percentiles
+            statistics.quantiles(self._resp_time_store, n=100)[p - 1] for p in percentiles
         ]
 
     @property

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -158,13 +158,12 @@ class GenericStatsOutput:
                 journey_name = message.get("journey")
                 self._error_journeys[journey_name] += 1
 
-    def _percentiles_with_thresholds(self):
-        percentiles = self._benchmark_percentiles.split(",")
-        return [(int(p.split(":")[0]), int(p.split(":")[1])) for p in percentiles]
-
     @property
     def percentiles_list_resp_time_store(self):
-        percentiles_thresholds_list = self._percentiles_with_thresholds()
+        percentiles = self._benchmark_percentiles.split(",")
+        percentiles_thresholds_list = [
+            (int(p.split(":")[0]), int(p.split(":")[1])) for p in percentiles
+        ]
         if not self._resp_time_store:
             return []
         quantiles = statistics.quantiles(self._resp_time_store, n=100)

--- a/mite/logoutput.py
+++ b/mite/logoutput.py
@@ -160,19 +160,15 @@ class GenericStatsOutput:
 
     def _percentiles_with_thresholds(self):
         percentiles = self._benchmark_percentiles.split(",")
-        percentile_values = [int(p.split(":")[0]) for p in percentiles]
-        percentile_thresholds = [int(p.split(":")[1]) for p in percentiles]
-        return percentile_values, percentile_thresholds
+        return [(int(p.split(":")[0]), int(p.split(":")[1])) for p in percentiles]
 
     @property
     def percentiles_list_resp_time_store(self):
-        percentiles, _ = self._percentiles_with_thresholds()
-        logging.info(f"Percentiles: {percentiles}")
+        percentiles_thresholds_list = self._percentiles_with_thresholds()
         if not self._resp_time_store:
-            return 0
-        return [
-            statistics.quantiles(self._resp_time_store, n=100)[p - 1] for p in percentiles
-        ]
+            return []
+        quantiles = statistics.quantiles(self._resp_time_store, n=100)
+        return [(p[0], p[1], quantiles[p[0] - 1]) for p in percentiles_thresholds_list]
 
     @property
     def mean_resp_time(self):


### PR DESCRIPTION
#### What is the change?
Improve how `mite` handles thresholds within benchmark report and enable dynamically adding new percentiles and thresholds. Utilise `statistics` module for quatiles to calculate integer percentiles.

Change `default_config_loader` logging from info to debug.

#### Does this change require a version increment:

- [ ] Major
- [ ] Minor
- [x] Patch
