### PR TITLE
Add kakfa adapter manager

### DIFF
--- a/mite_kafka/__init__.py
+++ b/mite_kafka/__init__.py
@@ -1,5 +1,7 @@
 import asyncio
+import threading
 from contextlib import asynccontextmanager
+from functools import wraps
 
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
 
@@ -21,6 +23,11 @@ class KafkaProducer:
             topic=topic,
             key=key,
         )
+
+    @asynccontextmanager
+    async def transaction(self, message):
+        async with self._context.transaction(message):
+            yield
 
     async def stop(self):
         await self._producer.stop()
@@ -69,3 +76,98 @@ def mite_kafka(func):
             return await func(ctx, *args, **kwargs)
 
     return wrapper
+
+
+class KafkaAdapterManager:
+    _producers = {}
+    _lock = threading.Lock()
+
+    @classmethod
+    async def get_producer(
+        cls, context, bootstrap_servers, adapter_id=None, *args, **kwargs
+    ):
+        if adapter_id is None:
+            adapter_id = "DEFAULT"
+        if cls._producers.get(adapter_id, None) is None:
+            with cls._lock:
+                if cls._producers.get(adapter_id, None) is None:
+                    cls._producers[f"{adapter_id}"] = KafkaProducer(context)
+                    await cls._producers.get(adapter_id).create_and_start(
+                        bootstrap_servers=bootstrap_servers, *args, **kwargs
+                    )
+        return cls._producers.get(adapter_id)
+
+
+@asynccontextmanager
+async def _kafka_managed_adapter_context_manager(
+    ctx,
+    bootstrap_servers,
+    only_consumer=False,
+    only_producer=False,
+    adapter_id=None,
+    *args,
+    **kwargs,
+):
+    if adapter_id:
+        ctx_producer_key = f"kafka_producer_{adapter_id}"
+    else:
+        ctx_producer_key = "kafka_producer"
+    if only_producer:
+        producer = await KafkaAdapterManager.get_producer(
+            ctx, bootstrap_servers, *args, **kwargs
+        )
+        setattr(ctx, ctx_producer_key, producer)
+    elif only_consumer:
+        # TODO: Implement consumer
+        raise Exception("only_consumer not yet implemented")
+    else:
+        producer = await KafkaAdapterManager.get_producer(
+            ctx, bootstrap_servers, *args, **kwargs
+        )
+        setattr(ctx, ctx_producer_key, producer)
+        # TODO: Add consumer once implemented
+    yield
+
+
+def mite_kafka_managed_adapter(
+    *args,
+    bootstrap_servers,
+    only_consumer=False,
+    only_producer=False,
+    security_protocol=None,
+    ssl_context=None,
+    value_serializer=None,
+    adapter_id=None,
+):
+    if only_consumer:
+        raise Exception("only_consumer not yet implemented")
+    if only_consumer and only_producer:
+        raise Exception("Cannot specify both only_consumer and only_producer")
+    if security_protocol is None:
+        security_protocol = "PLAINTEXT"
+
+    def wrapper_factory(func):
+        @wraps(func)
+        async def wrapper(ctx, *args, **kwargs):
+            async with _kafka_managed_adapter_context_manager(
+                ctx,
+                bootstrap_servers=bootstrap_servers,
+                only_consumer=only_consumer,
+                only_producer=only_producer,
+                security_protocol=security_protocol,
+                ssl_context=ssl_context,
+                value_serializer=value_serializer,
+                adapter_id=adapter_id,
+            ):
+                return await func(ctx, *args, **kwargs)
+
+        return wrapper
+
+    if len(args) == 0:
+        # invoked as @mite_kafka_managed_producer(producer_id=...) def foo(...)
+        return wrapper_factory
+    elif len(args) > 1:
+        raise Exception("Anomalous invocation of mite_kafka_managed_producer decorator")
+    else:
+        # len(args) == 1; invoked as @mite_kafka_managed_producer def foo(...)
+        return wrapper_factory(args[0])


### PR DESCRIPTION
#### What is the change?
Add a kafka adapter manager mechanism to allow and manager creation of long lived producers and consumer adapter
It should be completely backwards compatible as no existing code has been changed with the exception of test code where an example has been added on how the adapter and respective decorators can be used

#### Does this change require a version increment:

- [ ] Major
- [ ] Minor
- [x] Patch
