### PR TITLE
Revert "IDSREPERF-13 - Cython 3x migration"

### DIFF
--- a/acurl/pyproject.toml
+++ b/acurl/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "Cython>=3.1.3,<4.0.0"]
+requires = ["setuptools", "wheel", "Cython<3.0"]

--- a/acurl/setup.cfg
+++ b/acurl/setup.cfg
@@ -22,7 +22,7 @@ version = 1.0.8
 [options]
 install_requires =
     ujson>=4.1.0
-    uvloop>=0.21.0,<1.0.0
+    uvloop
 tests_require = pytest
 
 [aliases]

--- a/acurl/setup.py
+++ b/acurl/setup.py
@@ -20,7 +20,6 @@ setup(
         extensions,
         gdb_debug=True,
         compiler_directives={
-            "language_level": 3,
             "warn.undeclared": True,
             "warn.unreachable": True,
             "warn.maybe_uninitialized": True,

--- a/acurl/src/session.pyx
+++ b/acurl/src/session.pyx
@@ -32,7 +32,7 @@ cdef BufferNode* alloc_buffer_node(size_t size, char *data):
     node.next = NULL
     return node
 
-cdef size_t header_callback(char *ptr, size_t size, size_t nmemb, void *userdata) noexcept:
+cdef size_t header_callback(char *ptr, size_t size, size_t nmemb, void *userdata):
     cdef _Response response = <_Response>userdata
     cdef BufferNode* node = alloc_buffer_node(size * nmemb, ptr)
     if response.header_buffer == NULL:  # FIXME: unlikely
@@ -42,7 +42,7 @@ cdef size_t header_callback(char *ptr, size_t size, size_t nmemb, void *userdata
     response.header_buffer_tail = node
     return node.len
 
-cdef size_t body_callback(char *ptr, size_t size, size_t nmemb, void *userdata) noexcept:
+cdef size_t body_callback(char *ptr, size_t size, size_t nmemb, void *userdata):
     cdef _Response response = <_Response>userdata
     cdef BufferNode* node = alloc_buffer_node(size * nmemb, ptr)
     if response.body_buffer == NULL:  # FIXME: unlikely
@@ -99,7 +99,7 @@ cdef class Session:
             # the cycle collector.
             curl_share_cleanup(self.shared)
         else:
-            self.wrapper.loop.call_soon(lambda: cleanup_share(PyCapsule_New(self.shared, NULL, NULL)))
+            self.wrapper.loop.call_soon(cleanup_share, PyCapsule_New(self.shared, NULL, NULL))
 
     def cookies(self):
         cdef CURL* curl = curl_easy_init()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,5 +14,5 @@ pytest-httpbin
 pytest-httpserver
 sanic
 werkzeug==3.1.3
-uvloop>=0.21.0,<1.0.0
+uvloop~=0.19.0
 setuptools>=78.1.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Reverts sky-uk/mite#300

Unfortunately it causes a segmentation fault. Can be recreated with the following script:

```
#!/bin/bash -x
cat > s.py <<EOF
from mite_http import mite_http
scenario = lambda: [["s:journey", None, lambda s, e: 1],]
@mite_http
async def journey(ctx):
    await ctx.http.get("http://localhost:8000/")
EOF
python -m http.server & HTTP_SERVER_PID=$!
mite runner & RUNNER_PID=$!
mite controller s:scenario & CONTROLLER_PID=$!

cleanup() {
    kill $RUNNER_PID $CONTROLLER_PID $HTTP_SERVER_PID 2>/dev/null
    rm -f s.py
}
trap cleanup EXIT INT TERM

while kill -0 $RUNNER_PID 2>/dev/null && kill -0 $CONTROLLER_PID 2>/dev/null; do sleep 1; done
cleanup
```