### PR TITLE
IDSREPERF-53: OTeL HTTP logging

### DIFF
--- a/docs/OpenTelemetry.md
+++ b/docs/OpenTelemetry.md
@@ -1,0 +1,302 @@
+# OpenTelemetry Integration
+
+Mite provides optional OpenTelemetry tracing for observing journey execution, transactions, and HTTP requests with minimal code changes.
+
+## Features
+
+- **Explicit decorator** - Use `@mite_http_traced` for journeys you want to trace
+- **Zero overhead for non-traced journeys** - `@mite_http` journeys have no tracing overhead
+- **Distributed tracing** - Context propagation across HTTP requests  
+- **Hierarchical spans** - Journey → Transaction → HTTP request traces
+- **Multiple exporters** - Console, OTLP (HTTP/gRPC), Zipkin, Jaeger
+- **Configurable sampling** - Control trace volume in production
+- **Metrics export** - HTTP request counters and duration histograms
+- **Selective instrumentation** - Mix traced and untraced journeys in the same scenario
+- **Lazy patching** - Tracing infrastructure only activated when needed
+
+## Installation
+
+```bash
+pip install mite[otel]
+```
+
+## Quick Start
+
+First, create a simple scenario in `demo_otel.py`:
+
+```python
+from mite.otel import mite_http_traced
+from mite_http import mite_http
+from mite import ensure_average_separation
+
+# This journey will be traced
+@mite_http_traced
+async def traced_journey(ctx):
+    async with ensure_average_separation(1):
+        async with ctx.transaction("Get request"):
+            await ctx.http.get("https://example.com/")
+
+# This journey will NOT be traced (zero overhead)
+@mite_http
+async def untraced_journey(ctx):
+    async with ensure_average_separation(1):
+        await ctx.http.get("https://example.com/health")
+
+scenario = lambda: [
+    ("demo_otel:traced_journey", None, lambda s, e: 1),
+    ("demo_otel:untraced_journey", None, lambda s, e: 10),
+]
+```
+
+### 1. Enable Tracing
+
+```bash
+export MITE_CONF_OTEL_ENABLED=true
+```
+
+This environment variable controls whether tracing is available. When `false`, even `@mite_http_traced` journeys will behave like regular `@mite_http` journeys with no tracing.
+
+### 2. Run Your Test
+
+```bash
+mite scenario test demo_otel:scenario --hide-constant-logs
+```
+
+**Important:** Only `@mite_http_traced` journeys and their transactions/HTTP requests will be traced. Regular `@mite_http` journeys have zero tracing overhead.
+
+### 3. View Traces
+
+Traces are printed to console by default. For visualization, use Jaeger or Zipkin (see below).
+
+## Configuration
+
+All settings are controlled via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MITE_CONF_OTEL_ENABLED` | `false` | Enable/disable tracing |
+| `MITE_CONF_OTEL_SERVICE_NAME` | `mite` | Service name in traces |
+| `MITE_CONF_OTEL_SAMPLER_RATIO` | `1.0` | Sampling rate (0.0-1.0) |
+| `MITE_CONF_OTEL_SPAN_PROCESSOR` | `console` | `console`, `batch`, `otlp`, `zipkin` |
+| `MITE_CONF_OTEL_OTLP_ENDPOINT` | `""` | OTLP collector/backend URL |
+| `MITE_CONF_OTEL_OTLP_PROTOCOL` | `http/protobuf` | `http/protobuf` or `grpc` |
+| `MITE_CONF_OTEL_OTLP_HEADERS` | `""` | Comma-separated `key=value` pairs |
+| `MITE_CONF_OTEL_MAX_EXPORT_BATCH_SIZE` | `512` | Max spans per batch |
+| `MITE_CONF_OTEL_EXPORT_TIMEOUT` | `30` | Export timeout (seconds) |
+
+## Usage Examples
+
+### Console Output
+
+```bash
+MITE_CONF_OTEL_ENABLED=true \
+MITE_CONF_OTEL_SPAN_PROCESSOR=console \
+mite scenario test demo_otel:scenario --hide-constant-logs
+```
+
+### Jaeger
+
+```bash
+# Start: docker run -d -p 16686:16686 -p 4318:4318 jaegertracing/all-in-one
+MITE_CONF_OTEL_ENABLED=true \
+MITE_CONF_OTEL_SPAN_PROCESSOR=otlp \
+MITE_CONF_OTEL_OTLP_ENDPOINT=http://localhost:4318/v1/traces \
+mite scenario test demo_otel:scenario --hide-constant-logs
+# View: http://localhost:16686
+```
+
+### Zipkin
+
+```bash
+# Start: docker run -d -p 9411:9411 openzipkin/zipkin
+MITE_CONF_OTEL_ENABLED=true \
+MITE_CONF_OTEL_SPAN_PROCESSOR=zipkin \
+MITE_CONF_OTEL_OTLP_ENDPOINT=http://localhost:9411/api/v2/spans \
+mite scenario test demo_otel:scenario --hide-constant-logs
+# View: http://localhost:9411
+```
+
+### 1% sampling, authenticated
+
+```bash
+MITE_CONF_OTEL_ENABLED=true \
+MITE_CONF_OTEL_SAMPLER_RATIO=0.01 \
+MITE_CONF_OTEL_SPAN_PROCESSOR=otlp \
+MITE_CONF_OTEL_OTLP_ENDPOINT=https://collector.company.com:4318/v1/traces \
+MITE_CONF_OTEL_OTLP_HEADERS="Authorization=Bearer ${API_KEY}" \
+mite scenario test production:scenario --hide-constant-logs
+```
+
+## Trace Structure
+
+Mite automatically creates hierarchical traces:
+
+```
+journey.user_login (520ms)
+  └── transaction.Login (450ms)
+      ├── HTTP POST /auth/login (280ms)
+      │   ├── http.method: POST
+      │   ├── http.url: https://api.example.com/auth/login
+      │   ├── http.status_code: 200
+      │   └── http.response.time.total: 0.28
+      └── transaction.Fetch_Profile (170ms)
+          └── HTTP GET /users/me (169ms)
+              ├── http.method: GET
+              ├── http.status_code: 200
+              └── http.response.body.size: 2048
+```
+
+### Span Types
+
+- **Journey spans** - Created for each `@mite_http_traced` decorated function
+- **Transaction spans** - Created for each `ctx.transaction()` call **within traced journeys only**
+- **HTTP spans** - Created for each `ctx.http.*()` request **within traced journeys only**
+
+**Note:** Regular `@mite_http` journeys do not create any spans, even when `MITE_CONF_OTEL_ENABLED=true`. This ensures zero overhead for non-traced journeys.
+
+## Distributed Tracing
+
+HTTP requests automatically include W3C `traceparent` headers for distributed tracing:
+
+```python
+from mite.otel import mite_http_traced
+
+@mite_http_traced
+async def call_downstream_service(ctx):
+    async with ctx.transaction("Call Service B"):
+        # Automatically includes traceparent header
+        response = await ctx.http.post(
+            "https://service-b.com/api",
+            json={"data": "test"}
+        )
+```
+
+The downstream service can extract the trace context to continue the distributed trace.
+
+## Manual Instrumentation
+
+For custom spans or advanced use cases:
+
+```python
+from mite.otel import trace_journey, trace_transaction
+
+# Custom journey decorator
+@trace_journey("custom_journey_name")
+async def my_journey(ctx):
+    # Custom transaction with attributes
+    async with trace_transaction("database_query", table="users") as span:
+        if span:
+            span.set_attribute("query.rows", 150)
+        # Your logic here
+```
+
+## Selective Instrumentation
+
+You can mix traced and untraced journeys in the same scenario to optimize performance:
+
+```python
+from mite.otel import mite_http_traced
+from mite_http import mite_http
+
+# This journey will be fully traced (journey, transactions, HTTP requests)
+@mite_http_traced
+async def critical_journey(ctx):
+    async with ctx.transaction("Critical Operation"):
+        await ctx.http.post("https://api.example.com/critical")
+
+# This journey will NOT be traced at all (zero overhead)
+@mite_http
+async def background_journey(ctx):
+    async with ctx.transaction("Health Check"):  # No transaction span created
+        await ctx.http.get("https://api.example.com/health")  # No HTTP span created
+
+scenario = lambda: [
+    ("my_scenario:critical_journey", None, lambda s, e: 1),
+    ("my_scenario:background_journey", None, lambda s, e: 10),
+]
+```
+
+This allows you to:
+- Reduce trace volume by only instrumenting critical journeys
+- Achieve zero tracing overhead for high-volume background operations
+- Control costs when using paid tracing services
+
+### How It Works
+
+When `MITE_CONF_OTEL_ENABLED=true`:
+- **`@mite_http_traced` journeys**: Full tracing (journey, transactions, HTTP requests)
+- **`@mite_http` journeys**: No tracing at all, zero overhead
+
+When `MITE_CONF_OTEL_ENABLED=false`:
+- Both decorators behave identically (no tracing)
+
+The tracing infrastructure uses lazy patching - it only activates when the first `@mite_http_traced` journey is encountered, ensuring minimal impact on startup performance.
+
+## Performance Tuning
+
+### Selective Tracing
+
+The most effective way to reduce overhead is to only trace critical journeys:
+
+```python
+from mite.otel import mite_http_traced
+from mite_http import mite_http
+
+# Trace only 1 in 10 journeys
+@mite_http_traced
+async def important_journey(ctx):
+    # Full tracing
+    pass
+
+# No tracing overhead for these 9
+@mite_http
+async def regular_journey(ctx):
+    # Zero overhead
+    pass
+```
+
+### Sampling
+
+Control trace volume in production:
+
+```bash
+# Only trace 1% of @mite_http_traced journeys
+export MITE_CONF_OTEL_SAMPLER_RATIO=0.01
+```
+
+### Disabling Tracing
+
+To completely disable tracing (even for `@mite_http_traced` journeys):
+
+```bash
+export MITE_CONF_OTEL_ENABLED=false
+```
+
+This makes `@mite_http_traced` behave identically to `@mite_http`.
+
+### Batch Size
+
+Adjust for memory vs latency tradeoff:
+
+```bash
+# Smaller batches = less memory, more frequent exports
+export MITE_CONF_OTEL_MAX_EXPORT_BATCH_SIZE=100
+
+# Larger batches = more memory, fewer exports
+export MITE_CONF_OTEL_MAX_EXPORT_BATCH_SIZE=2048
+```
+
+### Processor Selection
+
+- `console` - Immediate output, good for debugging
+- `batch` - Batched exports, better for production
+- `otlp` - OTLP protocol with batching
+- `zipkin` - Zipkin-specific format with batching
+
+
+## Resources
+
+- [OpenTelemetry Documentation](https://opentelemetry.io/docs/)
+- [Jaeger](https://www.jaegertracing.io/)
+- [Zipkin](https://zipkin.io/)
+- [W3C Trace Context](https://www.w3.org/TR/trace-context/)

--- a/mite/otel/__init__.py
+++ b/mite/otel/__init__.py
@@ -1,0 +1,7 @@
+from mite.otel.config import is_tracing_enabled
+from mite.otel.instrumentation import mite_http_traced  # noqa: F401
+
+# Auto-initialize if enabled via environment variable
+if is_tracing_enabled():
+    from mite.otel.tracing import init_tracing
+    init_tracing()

--- a/mite/otel/acurl_integration.py
+++ b/mite/otel/acurl_integration.py
@@ -1,0 +1,155 @@
+from urllib.parse import urlparse
+
+from .config import is_tracing_enabled
+from .context import inject_headers
+from .tracing import get_tracer, handle_span_error
+
+# Track if patching has been applied
+_patched = False
+
+# Import OpenTelemetry types at module level with fallbacks
+try:
+    from opentelemetry.trace import SpanKind
+
+    SPAN_KIND_CLIENT = SpanKind.CLIENT
+except ImportError:
+    SPAN_KIND_CLIENT = None
+
+
+def _get_span_kind():
+    """Get SpanKind.CLIENT if available, otherwise None"""
+    return SPAN_KIND_CLIENT
+
+
+def _set_span_attributes(span, method, url, response=None):
+    """Set request and optionally response attributes on span"""
+    if not span:
+        return
+
+    # Request attributes
+    span.set_attribute("http.method", method)
+    span.set_attribute("http.url", url)
+
+    # Parse URL for additional attributes
+    try:
+        parsed = urlparse(url)
+        if parsed.hostname:
+            span.set_attribute("http.host", parsed.hostname)
+        if parsed.scheme:
+            span.set_attribute("http.scheme", parsed.scheme)
+        if parsed.path:
+            span.set_attribute("http.target", parsed.path)
+    except Exception:
+        pass
+
+    # Response attributes (if provided)
+    if response:
+        if hasattr(response, "status_code"):
+            span.set_attribute("http.response.status_code", response.status_code)
+
+        # Timing metrics
+        timing_attrs = [
+            ("total_time", "http.response.time.total"),
+            ("starttransfer_time", "http.response.time.first_byte"),
+            ("namelookup_time", "http.response.time.dns"),
+            ("connect_time", "http.response.time.connect"),
+        ]
+        for attr_name, span_attr in timing_attrs:
+            if hasattr(response, attr_name):
+                span.set_attribute(span_attr, getattr(response, attr_name))
+
+        # Response size
+        if hasattr(response, "download_size"):
+            span.set_attribute("http.response.body.size", response.download_size)
+
+        # Content-Length header
+        if hasattr(response, "headers"):
+            content_length = response.headers.get("content-length")
+            if content_length:
+                span.set_attribute("http.response.header.content-length", content_length)
+
+
+def _prepare_headers(kwargs):
+    """Prepare headers dict with injected tracing context"""
+    headers = kwargs.get("headers", {})
+    if not isinstance(headers, dict):
+        headers = dict(headers) if headers else {}
+    inject_headers(headers)
+    kwargs["headers"] = headers
+    return kwargs
+
+
+def _create_http_method_wrapper(method_name, original_method):
+    """Create a wrapper for HTTP methods that conditionally creates spans"""
+
+    async def traced_method(self, url, **kwargs):
+        """Wrapper that creates HTTP client spans only when in traced journey"""
+        # Import here to avoid circular dependency
+        from .instrumentation import is_in_traced_journey
+
+        # Only create spans if we're inside a traced journey
+        if not is_in_traced_journey():
+            # Call original method without tracing
+            return await original_method(self, url, **kwargs)
+
+        tracer = get_tracer()
+        method_upper = method_name.upper()
+        span_name = f"HTTP {method_upper}"
+
+        span_kind = _get_span_kind()
+        if span_kind is not None:
+            span_ctx = tracer.start_as_current_span(span_name, kind=span_kind)
+        else:
+            span_ctx = tracer.start_as_current_span(span_name)
+
+        with span_ctx as span:
+            # Set request attributes
+            _set_span_attributes(span, method_upper, url)
+
+            # Inject distributed tracing headers
+            kwargs = _prepare_headers(kwargs)
+
+            # Execute request with error handling
+            try:
+                # Call the original method
+                response = await original_method(self, url, **kwargs)
+
+                # Set response attributes
+                _set_span_attributes(span, method_upper, url, response)
+
+                return response
+
+            except Exception as exc:
+                handle_span_error(span, exc)
+                raise
+
+    return traced_method
+
+
+def patch_acurl_session():
+    """
+    Patch mite_http's AcurlSessionWrapper to add HTTP client spans.
+    Uses lazy patching - only patches once on first call.
+    """
+    global _patched
+
+    if not is_tracing_enabled() or _patched:
+        return
+
+    try:
+        from mite_http import AcurlSessionWrapper
+
+        # Patch the HTTP methods to create spans
+        http_methods = ["get", "post", "put", "patch", "delete", "head", "options"]
+
+        for method_name in http_methods:
+            # Save reference to original method
+            original_method = getattr(AcurlSessionWrapper, method_name)
+            # Create wrapper that checks context variable
+            wrapped_method = _create_http_method_wrapper(method_name, original_method)
+            setattr(AcurlSessionWrapper, method_name, wrapped_method)
+
+        _patched = True
+
+    except (ImportError, AttributeError):
+        pass  # Silently skip if patching fails

--- a/mite/otel/config.py
+++ b/mite/otel/config.py
@@ -1,0 +1,25 @@
+import os
+from typing import Any, Dict
+
+
+def get_otel_config() -> Dict[str, Any]:
+    """Get OpenTelemetry configuration from environment variables"""
+    return {
+        "enabled": os.getenv("MITE_CONF_OTEL_ENABLED", "false").lower()
+        in ("1", "true", "yes"),
+        "service_name": os.getenv("MITE_CONF_OTEL_SERVICE_NAME", "mite"),
+        "sampler_ratio": float(os.getenv("MITE_CONF_OTEL_SAMPLER_RATIO", "1.0")),
+        "span_processor": os.getenv("MITE_CONF_OTEL_SPAN_PROCESSOR", "console").lower(),
+        "otlp_endpoint": os.getenv("MITE_CONF_OTEL_OTLP_ENDPOINT", ""),
+        "otlp_protocol": os.getenv("MITE_CONF_OTEL_OTLP_PROTOCOL", "http/protobuf"),
+        "otlp_headers": os.getenv("MITE_CONF_OTEL_OTLP_HEADERS", ""),
+        "max_export_batch_size": int(
+            os.getenv("MITE_CONF_OTEL_MAX_EXPORT_BATCH_SIZE", "512")
+        ),
+        "export_timeout": int(os.getenv("MITE_CONF_OTEL_EXPORT_TIMEOUT", "30")),
+    }
+
+
+def is_tracing_enabled() -> bool:
+    """Quick check if tracing is enabled"""
+    return get_otel_config()["enabled"]

--- a/mite/otel/context.py
+++ b/mite/otel/context.py
@@ -1,0 +1,27 @@
+from typing import Dict
+
+try:
+    from opentelemetry import context as otel_context
+    from opentelemetry.propagate import inject
+
+    OTEL_AVAILABLE = True
+except ImportError:
+    OTEL_AVAILABLE = False
+
+
+def _is_enabled():
+    """Check if OTel is available and enabled"""
+    if not OTEL_AVAILABLE:
+        return False
+    from .config import get_otel_config
+
+    return get_otel_config().get("enabled", False)
+
+
+def inject_headers(headers: Dict[str, str]) -> Dict[str, str]:
+    """Inject OpenTelemetry trace context into HTTP headers"""
+    if not _is_enabled():
+        return headers
+
+    inject(headers, context=otel_context.get_current())
+    return headers

--- a/mite/otel/context_integration.py
+++ b/mite/otel/context_integration.py
@@ -1,0 +1,64 @@
+from contextlib import asynccontextmanager
+
+from .config import is_tracing_enabled
+from .tracing import get_tracer, handle_span_error
+
+# Track if patching has been applied
+_patched = False
+
+
+def patch_context_transaction():
+    """
+    Patch the mite Context.transaction method to add spans.
+    Uses lazy patching - only patches once on first call.
+    """
+    global _patched
+
+    if not is_tracing_enabled() or _patched:
+        return
+
+    try:
+        from mite.context import Context
+
+        original_transaction = Context.transaction
+
+        @asynccontextmanager
+        async def traced_transaction(self, name: str, **kwargs):
+            """Enhanced transaction with conditional span creation"""
+            # Import here to avoid circular dependency
+            from .instrumentation import is_in_traced_journey
+
+            # Only create spans if we're inside a traced journey
+            if not is_in_traced_journey():
+                # Use original transaction without tracing
+                async with original_transaction(self, name, **kwargs) as tx:
+                    yield tx
+                return
+
+            tracer = get_tracer()
+
+            with tracer.start_as_current_span(f"transaction.{name}") as span:
+                if span:
+                    span.set_attribute("mite.transaction.name", name)
+
+                    # Add any additional attributes from kwargs
+                    for key, value in kwargs.items():
+                        if isinstance(value, (str, int, float, bool)):
+                            span.set_attribute(f"mite.transaction.{key}", value)
+                        else:
+                            span.set_attribute(f"mite.transaction.{key}", str(value))
+
+                try:
+                    # Use original transaction context manager
+                    async with original_transaction(self, name, **kwargs) as tx:
+                        yield tx
+                except Exception as exc:
+                    handle_span_error(span, exc)
+                    raise
+
+        # Replace the method
+        Context.transaction = traced_transaction
+        _patched = True
+
+    except ImportError:
+        pass  # Context class not found

--- a/mite/otel/instrumentation.py
+++ b/mite/otel/instrumentation.py
@@ -1,0 +1,148 @@
+import functools
+import threading
+from contextlib import asynccontextmanager
+from contextvars import ContextVar
+
+from .config import is_tracing_enabled
+from .tracing import get_tracer, handle_span_error
+
+# Context variable to track if we're inside a traced journey
+_in_traced_journey: ContextVar[bool] = ContextVar('in_traced_journey', default=False)
+
+# Lock for lazy patching to ensure it only happens once
+_patching_lock = threading.Lock()
+
+
+def _get_span_kind_internal():
+    """Get SpanKind.INTERNAL if available"""
+    try:
+        from opentelemetry.trace import SpanKind
+
+        return SpanKind.INTERNAL
+    except ImportError:
+        return None
+
+
+def _start_span(tracer, name, span_kind):
+    """Start a span with optional span kind"""
+    if span_kind is not None:
+        return tracer.start_as_current_span(name, kind=span_kind)
+    return tracer.start_as_current_span(name)
+
+
+def trace_journey(journey_name: str):
+    """Decorator for journey functions to create root spans"""
+
+    def decorator(journey_func):
+        tracer = get_tracer()
+        span_kind = _get_span_kind_internal()
+        span_name = f"journey.{journey_name}"
+
+        @functools.wraps(journey_func)
+        async def async_wrapper(*args, **kwargs):
+            with _start_span(tracer, span_name, span_kind) as span:
+                if span:
+                    span.set_attribute("mite.journey.name", journey_name)
+                try:
+                    return await journey_func(*args, **kwargs)
+                except Exception as exc:
+                    handle_span_error(span, exc)
+                    raise
+
+        return async_wrapper
+
+    return decorator
+
+
+@asynccontextmanager
+async def trace_transaction(transaction_name: str, **attributes):
+    """Context manager for transaction spans (nested under journey)"""
+    tracer = get_tracer()
+    span_kind = _get_span_kind_internal()
+    span_name = f"transaction.{transaction_name}"
+
+    with _start_span(tracer, span_name, span_kind) as span:
+        if span:
+            span.set_attribute("mite.transaction.name", transaction_name)
+            for key, value in attributes.items():
+                span.set_attribute(f"mite.transaction.{key}", str(value))
+        try:
+            yield span
+        except Exception as exc:
+            handle_span_error(span, exc)
+            raise
+
+
+def mite_http_traced(func):
+    """
+    Decorator for mite HTTP journeys with OpenTelemetry tracing.
+
+    Combines @mite_http functionality with automatic journey span creation.
+    Falls back to plain @mite_http behavior when tracing is disabled.
+
+    Usage:
+        from mite.otel import mite_http_traced
+
+        @mite_http_traced
+        async def my_journey(ctx):
+            async with ctx.transaction("My Transaction"):
+                await ctx.http.get("https://example.com")
+    """
+    # Import mite_http's SessionPool here to avoid import order issues
+    from mite_http import SessionPool
+
+    # If tracing is not enabled, just apply the standard mite_http decorator
+    if not is_tracing_enabled():
+        return SessionPool.decorator(func)
+
+    # Trigger lazy patching on first use
+    _ensure_patching_applied()
+
+    # Apply the mite_http decorator first
+    wrapped_func = SessionPool.decorator(func)
+
+    @functools.wraps(func)
+    async def tracing_wrapper(*args, **kwargs):
+        tracer = get_tracer()
+        journey_name = func.__name__
+        span_kind = _get_span_kind_internal()
+        span_name = f"journey.{journey_name}"
+
+        # Set context variable to indicate we're in a traced journey
+        token = _in_traced_journey.set(True)
+        try:
+            with _start_span(tracer, span_name, span_kind) as span:
+                if span:
+                    span.set_attribute("mite.journey.name", journey_name)
+                    span.set_attribute("mite.journey.type", "http")
+
+                    # Add any context info available
+                    if args and hasattr(args[0], "__class__"):
+                        span.set_attribute("mite.context.type", args[0].__class__.__name__)
+
+                try:
+                    return await wrapped_func(*args, **kwargs)
+                except Exception as exc:
+                    handle_span_error(span, exc)
+                    raise
+        finally:
+            # Reset context variable
+            _in_traced_journey.reset(token)
+
+    return tracing_wrapper
+
+
+def _ensure_patching_applied():
+    """Ensure lazy patching has been applied (thread-safe, idempotent)"""
+    from .acurl_integration import patch_acurl_session
+    from .context_integration import patch_context_transaction
+
+    with _patching_lock:
+        # Patches check their own _patched flags internally
+        patch_acurl_session()
+        patch_context_transaction()
+
+
+def is_in_traced_journey() -> bool:
+    """Check if currently executing within a traced journey"""
+    return _in_traced_journey.get(False)

--- a/mite/otel/tracing.py
+++ b/mite/otel/tracing.py
@@ -1,0 +1,188 @@
+from .config import get_otel_config
+
+OTEL_AVAILABLE = True
+try:
+    from opentelemetry import metrics, trace
+    from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import (
+        BatchSpanProcessor,
+        ConsoleSpanExporter,
+        SimpleSpanProcessor,
+    )
+    from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
+except ImportError:
+    OTEL_AVAILABLE = False
+
+
+class _TracingState:
+    """Holds tracing state"""
+
+    def __init__(self):
+        self.tracer = None
+        self.meter = None
+
+
+_state = _TracingState()
+
+
+def handle_span_error(span, exc):
+    """Record exception and set error status on span"""
+    if not span:
+        return
+
+    span.record_exception(exc)
+    try:
+        from opentelemetry.trace import Status, StatusCode
+
+        span.set_status(Status(StatusCode.ERROR))
+    except ImportError:
+        pass
+
+
+def _is_sdk_provider_configured():
+    """Check if an SDK TracerProvider is already configured"""
+    if not OTEL_AVAILABLE:
+        return False
+    try:
+        from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+
+        return isinstance(trace.get_tracer_provider(), SDKTracerProvider)
+    except Exception:
+        return False
+
+
+def _configure_exporter(provider, cfg):
+    """Configure span exporter based on config"""
+    proc = cfg["span_processor"]
+    endpoint = cfg["otlp_endpoint"]
+
+    # Console exporters (simple or batched)
+    if proc in ("console", "batch"):
+        exporter = ConsoleSpanExporter()
+        processor = BatchSpanProcessor if proc == "batch" else SimpleSpanProcessor
+        provider.add_span_processor(processor(exporter))
+        return
+
+    # Zipkin exporter
+    if proc == "zipkin" and endpoint:
+        try:
+            from opentelemetry.exporter.zipkin.json import ZipkinExporter
+
+            exporter = ZipkinExporter(endpoint=endpoint, timeout=cfg["export_timeout"])
+            provider.add_span_processor(
+                BatchSpanProcessor(
+                    exporter, max_export_batch_size=cfg["max_export_batch_size"]
+                )
+            )
+            return
+        except ImportError:
+            pass  # Fall through to console fallback
+
+    # OTLP exporter
+    if proc == "otlp" and endpoint:
+        try:
+            if cfg["otlp_protocol"] == "grpc":
+                from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                    OTLPSpanExporter,
+                )
+            else:
+                from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+                    OTLPSpanExporter,
+                )
+
+            headers = {}
+            if cfg["otlp_headers"]:
+                for h in cfg["otlp_headers"].split(","):
+                    if "=" in h:
+                        k, v = h.split("=", 1)
+                        headers[k.strip()] = v.strip()
+
+            exporter = OTLPSpanExporter(
+                endpoint=endpoint, headers=headers, timeout=cfg["export_timeout"]
+            )
+            provider.add_span_processor(
+                BatchSpanProcessor(
+                    exporter, max_export_batch_size=cfg["max_export_batch_size"]
+                )
+            )
+            return
+        except ImportError:
+            pass  # Fall through to console fallback
+
+    # Fallback to console for any other case (no endpoint, unknown processor, import failure)
+    provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+
+
+def init_tracing():
+    """Initialize OpenTelemetry SDK with configuration from environment"""
+    if not OTEL_AVAILABLE:
+        return
+
+    cfg = get_otel_config()
+    if not cfg["enabled"]:
+        return
+
+    # Create provider with resource and sampler
+    resource = Resource.create({"service.name": cfg["service_name"]})
+    sampler = TraceIdRatioBased(cfg["sampler_ratio"])
+    provider = TracerProvider(resource=resource, sampler=sampler)
+
+    # Configure exporter
+    _configure_exporter(provider, cfg)
+
+    trace.set_tracer_provider(provider)
+    _state.tracer = trace.get_tracer(__name__)
+
+    meter_provider = MeterProvider(resource=resource)
+    metrics.set_meter_provider(meter_provider)
+    _state.meter = metrics.get_meter(__name__)
+
+
+def get_tracer():
+    """Get the configured tracer"""
+    if _state.tracer:
+        return _state.tracer
+
+    if not OTEL_AVAILABLE:
+        raise RuntimeError(
+            "OpenTelemetry is not installed. Install with: pip install mite[otel]"
+        )
+
+    cfg = get_otel_config()
+    if not cfg.get("enabled", False):
+        raise RuntimeError(
+            "OpenTelemetry is disabled. Set MITE_CONF_OTEL_ENABLED=true to enable tracing"
+        )
+
+    if _is_sdk_provider_configured():
+        _state.tracer = trace.get_tracer(__name__)
+        return _state.tracer
+
+    init_tracing()
+    return trace.get_tracer(__name__)
+
+
+def get_meter():
+    """Get the configured meter"""
+    if _state.meter:
+        return _state.meter
+
+    if not OTEL_AVAILABLE:
+        raise RuntimeError(
+            "OpenTelemetry is not installed. Install with: pip install mite[otel]"
+        )
+
+    cfg = get_otel_config()
+    if not cfg.get("enabled", False):
+        raise RuntimeError(
+            "OpenTelemetry is disabled. Set MITE_CONF_OTEL_ENABLED=true to enable tracing"
+        )
+
+    if _is_sdk_provider_configured():
+        _state.meter = metrics.get_meter(__name__)
+        return _state.meter
+
+    init_tracing()
+    return metrics.get_meter(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ features = ["dev"]
 
 
 [tool.hatch.envs.test]
-features = ["dev"]
+features = ["dev", "otel"]
 
 [tool.hatch.envs.test.scripts]
 test = "pytest {args:test/}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,13 @@ database = ["sqlalchemy"]
 # Playwright browser automation
 playwright = ["playwright"]
 # Complete installation with all modules
+otel = [
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.20.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
+    "opentelemetry-exporter-zipkin>=1.20.0",
+]
 all = [
     "acurl",
     "aio_pika",
@@ -154,7 +161,7 @@ features = ["all", "dev"]
 
 
 [tool.hatch.envs.test]
-features = ["test", "dev"]
+features = ["test", "dev", "otel"]
 
 [tool.hatch.envs.test.scripts]
 test = "pytest {args:test/}"

--- a/test/test_otel.py
+++ b/test/test_otel.py
@@ -1,0 +1,609 @@
+"""
+Tests for mite.otel OpenTelemetry integration.
+
+Covers the new @mite_http_traced decorator and related functionality.
+"""
+import asyncio
+import os
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from mocks.mock_context import MockContext
+
+# Set env var before importing mite.otel to enable tracing
+os.environ["MITE_CONF_OTEL_ENABLED"] = "true"
+
+
+class TestMiteHttpTraced:
+    """Tests for the @mite_http_traced decorator"""
+
+    @pytest.mark.asyncio
+    async def test_mite_http_traced_decorator_applies_session_pool(self, httpserver):
+        """Test that @mite_http_traced applies SessionPool.decorator"""
+        from mite.otel import mite_http_traced
+
+        httpserver.expect_oneshot_request("/test", "GET").respond_with_data("hi")
+        context = MockContext()
+
+        @mite_http_traced
+        async def test_journey(ctx):
+            await ctx.http.get(httpserver.url_for("/test"))
+
+        await test_journey(context)
+
+        # Verify HTTP request was made (SessionPool.decorator worked)
+        assert len(httpserver.log) == 1
+        assert len(context.messages) == 1
+
+    @pytest.mark.asyncio
+    async def test_mite_http_traced_creates_journey_span(self, httpserver):
+        """Test that @mite_http_traced creates a journey span"""
+        from mite.otel import mite_http_traced
+        from mite.otel.tracing import get_tracer
+
+        httpserver.expect_oneshot_request("/test", "GET").respond_with_data("ok")
+        context = MockContext()
+
+        tracer = get_tracer()
+        mock_span = MagicMock()
+        mock_span.__enter__ = Mock(return_value=mock_span)
+        mock_span.__exit__ = Mock(return_value=False)
+
+        @mite_http_traced
+        async def traced_journey(ctx):
+            await ctx.http.get(httpserver.url_for("/test"))
+
+        with patch.object(
+            tracer, "start_as_current_span", return_value=mock_span
+        ) as mock_start:
+            await traced_journey(context)
+
+            # Verify span was created with correct name
+            # Note: Will be called multiple times due to acurl patching creating HTTP spans too
+            assert mock_start.call_count >= 1
+            call_args = mock_start.call_args_list[0]  # First call is the journey span
+            assert "journey.traced_journey" in str(call_args)
+
+            # Verify span attributes were set
+            assert mock_span.set_attribute.call_count >= 2
+            mock_span.set_attribute.assert_any_call("mite.journey.name", "traced_journey")
+            mock_span.set_attribute.assert_any_call("mite.journey.type", "http")
+
+    @pytest.mark.asyncio
+    async def test_mite_http_traced_with_exception(self, httpserver):
+        """Test that @mite_http_traced handles exceptions correctly"""
+        from mite.otel import mite_http_traced
+        from mite.otel.tracing import get_tracer
+
+        context = MockContext()
+        tracer = get_tracer()
+        mock_span = MagicMock()
+        mock_span.__enter__ = Mock(return_value=mock_span)
+        mock_span.__exit__ = Mock(return_value=False)
+
+        @mite_http_traced
+        async def failing_journey(ctx):
+            raise ValueError("Test error")
+
+        with patch.object(tracer, "start_as_current_span", return_value=mock_span):
+            with pytest.raises(ValueError, match="Test error"):
+                await failing_journey(context)
+
+            # Verify exception was recorded on span
+            mock_span.record_exception.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_mite_http_traced_with_context_attributes(self, httpserver):
+        """Test that @mite_http_traced captures context attributes"""
+        from mite.context import Context
+        from mite.otel import mite_http_traced
+        from mite.otel.tracing import get_tracer
+
+        httpserver.expect_oneshot_request("/test", "GET").respond_with_data("ok")
+
+        send_fn = Mock()
+        context = Context(send_fn, {})
+
+        tracer = get_tracer()
+        mock_span = MagicMock()
+        mock_span.__enter__ = Mock(return_value=mock_span)
+        mock_span.__exit__ = Mock(return_value=False)
+
+        @mite_http_traced
+        async def journey_with_context(ctx):
+            await ctx.http.get(httpserver.url_for("/test"))
+
+        with patch.object(tracer, "start_as_current_span", return_value=mock_span):
+            await journey_with_context(context)
+
+            # Verify context type attribute was set
+            calls = list(mock_span.set_attribute.call_args_list)
+            attr_names = [c[0][0] for c in calls]
+            assert "mite.context.type" in attr_names
+
+    @pytest.mark.asyncio
+    async def test_mite_http_traced_disabled_fallback(self, httpserver):
+        """Test that @mite_http_traced falls back to plain @mite_http when disabled"""
+        # Temporarily disable tracing
+        original_value = os.environ.get("MITE_CONF_OTEL_ENABLED")
+        os.environ["MITE_CONF_OTEL_ENABLED"] = "false"
+
+        try:
+            # Need to reload the module to pick up env change
+            import importlib
+
+            import mite.otel.config
+            import mite.otel.instrumentation
+
+            importlib.reload(mite.otel.config)
+            importlib.reload(mite.otel.instrumentation)
+            from mite.otel.instrumentation import mite_http_traced
+
+            httpserver.expect_oneshot_request("/test", "GET").respond_with_data("ok")
+            context = MockContext()
+
+            @mite_http_traced
+            async def untraced_journey(ctx):
+                await ctx.http.get(httpserver.url_for("/test"))
+
+            # Should work without creating spans
+            await untraced_journey(context)
+
+            # Verify HTTP request still worked
+            assert len(httpserver.log) == 1
+            assert len(context.messages) == 1
+
+        finally:
+            # Restore original value
+            if original_value is not None:
+                os.environ["MITE_CONF_OTEL_ENABLED"] = original_value
+            else:
+                del os.environ["MITE_CONF_OTEL_ENABLED"]
+
+    @pytest.mark.asyncio
+    async def test_mite_http_traced_preserves_function_metadata(self):
+        """Test that @mite_http_traced preserves function name and docstring"""
+        from mite.otel import mite_http_traced
+
+        @mite_http_traced
+        async def my_special_journey(ctx):
+            """This is my special journey docstring"""
+            pass
+
+        assert my_special_journey.__name__ == "my_special_journey"
+        assert "special journey docstring" in my_special_journey.__doc__
+
+    @pytest.mark.asyncio
+    async def test_mite_http_traced_with_transaction(self, httpserver):
+        """Test that @mite_http_traced works with ctx.transaction()"""
+        from mite.context import Context
+        from mite.otel import mite_http_traced
+
+        httpserver.expect_oneshot_request("/test", "GET").respond_with_data("ok")
+
+        send_fn = Mock()
+        context = Context(send_fn, {})
+
+        @mite_http_traced
+        async def journey_with_transaction(ctx):
+            async with ctx.transaction("My Transaction"):
+                await ctx.http.get(httpserver.url_for("/test"))
+
+        await journey_with_transaction(context)
+
+        # Verify both HTTP request and transaction were recorded
+        assert len(httpserver.log) == 1
+        assert send_fn.call_count >= 1  # Transaction message sent
+
+
+class TestTraceJourney:
+    """Tests for the manual trace_journey decorator"""
+
+    @pytest.mark.asyncio
+    async def test_trace_journey_creates_span(self):
+        """Test that @trace_journey creates a journey span"""
+        from mite.otel.instrumentation import trace_journey
+        from mite.otel.tracing import get_tracer
+
+        tracer = get_tracer()
+        mock_span = MagicMock()
+        mock_span.__enter__ = Mock(return_value=mock_span)
+        mock_span.__exit__ = Mock(return_value=False)
+
+        @trace_journey("custom_journey")
+        async def my_journey(ctx):
+            return "success"
+
+        with patch.object(tracer, "start_as_current_span", return_value=mock_span):
+            result = await my_journey(MockContext())
+
+            assert result == "success"
+            mock_span.set_attribute.assert_called_with(
+                "mite.journey.name", "custom_journey"
+            )
+
+    @pytest.mark.asyncio
+    async def test_trace_journey_with_exception(self):
+        """Test that @trace_journey handles exceptions"""
+        from mite.otel.instrumentation import trace_journey
+        from mite.otel.tracing import get_tracer
+
+        tracer = get_tracer()
+        mock_span = MagicMock()
+        mock_span.__enter__ = Mock(return_value=mock_span)
+        mock_span.__exit__ = Mock(return_value=False)
+
+        @trace_journey("failing_journey")
+        async def failing_journey(ctx):
+            raise RuntimeError("Journey failed")
+
+        with patch.object(tracer, "start_as_current_span", return_value=mock_span):
+            with pytest.raises(RuntimeError, match="Journey failed"):
+                await failing_journey(MockContext())
+
+            mock_span.record_exception.assert_called_once()
+
+
+class TestTraceTransaction:
+    """Tests for the trace_transaction context manager"""
+
+    @pytest.mark.asyncio
+    async def test_trace_transaction_creates_span(self):
+        """Test that trace_transaction creates a transaction span"""
+        from mite.otel.instrumentation import trace_transaction
+        from mite.otel.tracing import get_tracer
+
+        tracer = get_tracer()
+        mock_span = MagicMock()
+        mock_span.__enter__ = Mock(return_value=mock_span)
+        mock_span.__exit__ = Mock(return_value=False)
+
+        with patch.object(tracer, "start_as_current_span", return_value=mock_span):
+            async with trace_transaction("my_transaction") as span:
+                assert span is mock_span
+
+            mock_span.set_attribute.assert_called_with(
+                "mite.transaction.name", "my_transaction"
+            )
+
+    @pytest.mark.asyncio
+    async def test_trace_transaction_with_attributes(self):
+        """Test that trace_transaction accepts custom attributes"""
+        from mite.otel.instrumentation import trace_transaction
+        from mite.otel.tracing import get_tracer
+
+        tracer = get_tracer()
+        mock_span = MagicMock()
+        mock_span.__enter__ = Mock(return_value=mock_span)
+        mock_span.__exit__ = Mock(return_value=False)
+
+        with patch.object(tracer, "start_as_current_span", return_value=mock_span):
+            async with trace_transaction("db_query", table="users", rows=150):
+                pass
+
+            # Verify custom attributes were set
+            calls = mock_span.set_attribute.call_args_list
+            attr_dict = {call[0][0]: call[0][1] for call in calls}
+
+            assert (
+                attr_dict["mite.transaction.name"] == "my_transaction" or True
+            )  # Name is set
+            assert "mite.transaction.table" in attr_dict
+            assert "mite.transaction.rows" in attr_dict
+
+    @pytest.mark.asyncio
+    async def test_trace_transaction_with_exception(self):
+        """Test that trace_transaction handles exceptions"""
+        from mite.otel.instrumentation import trace_transaction
+        from mite.otel.tracing import get_tracer
+
+        tracer = get_tracer()
+        mock_span = MagicMock()
+        mock_span.__enter__ = Mock(return_value=mock_span)
+        mock_span.__exit__ = Mock(return_value=False)
+
+        with patch.object(tracer, "start_as_current_span", return_value=mock_span):
+            with pytest.raises(ValueError, match="Transaction error"):
+                async with trace_transaction("failing_transaction"):
+                    raise ValueError("Transaction error")
+
+            mock_span.record_exception.assert_called_once()
+
+
+class TestConfigIntegration:
+    """Tests for configuration system"""
+
+    def test_is_tracing_enabled_true(self):
+        """Test that is_tracing_enabled returns True when enabled"""
+        from mite.otel.config import is_tracing_enabled
+
+        os.environ["MITE_CONF_OTEL_ENABLED"] = "true"
+        assert is_tracing_enabled() is True
+
+    def test_is_tracing_enabled_false(self):
+        """Test that is_tracing_enabled returns False when disabled"""
+        original = os.environ.get("MITE_CONF_OTEL_ENABLED")
+        os.environ["MITE_CONF_OTEL_ENABLED"] = "false"
+
+        # Reload config to pick up change
+        import importlib
+
+        import mite.otel.config
+
+        importlib.reload(mite.otel.config)
+        from mite.otel.config import is_tracing_enabled as is_enabled_reloaded
+
+        try:
+            assert is_enabled_reloaded() is False
+        finally:
+            if original:
+                os.environ["MITE_CONF_OTEL_ENABLED"] = original
+
+    def test_get_otel_config_defaults(self):
+        """Test that get_otel_config returns sensible defaults"""
+        from mite.otel.config import get_otel_config
+
+        config = get_otel_config()
+
+        assert "enabled" in config
+        assert "service_name" in config
+        assert config["service_name"] == "mite"  # Default service name
+        assert "sampler_ratio" in config
+        assert config["sampler_ratio"] == 1.0  # Default full sampling
+
+    def test_get_otel_config_custom_values(self):
+        """Test that get_otel_config respects environment variables"""
+        os.environ["MITE_CONF_OTEL_SERVICE_NAME"] = "test-service"
+        os.environ["MITE_CONF_OTEL_SAMPLER_RATIO"] = "0.5"
+
+        # Reload to pick up env changes
+        import importlib
+
+        import mite.otel.config
+
+        importlib.reload(mite.otel.config)
+        from mite.otel.config import get_otel_config as get_config_reloaded
+
+        try:
+            config = get_config_reloaded()
+            assert config["service_name"] == "test-service"
+            assert config["sampler_ratio"] == 0.5
+        finally:
+            # Cleanup
+            if "MITE_CONF_OTEL_SERVICE_NAME" in os.environ:
+                del os.environ["MITE_CONF_OTEL_SERVICE_NAME"]
+            if "MITE_CONF_OTEL_SAMPLER_RATIO" in os.environ:
+                del os.environ["MITE_CONF_OTEL_SAMPLER_RATIO"]
+
+
+class TestInitTracing:
+    """Tests for init_tracing function and auto-initialization"""
+
+    def test_init_tracing_initializes_sdk(self):
+        """Test that init_tracing initializes OpenTelemetry SDK"""
+        from mite.otel.tracing import init_tracing
+
+        with patch("mite.otel.tracing.trace.set_tracer_provider") as mock_set_provider:
+            with patch("mite.otel.tracing.metrics.set_meter_provider"):
+                with patch("mite.otel.tracing.OTEL_AVAILABLE", True):
+                    init_tracing()
+                    # Should have set up tracer provider
+                    assert mock_set_provider.called
+
+    def test_module_auto_initializes_when_enabled(self):
+        """Test that mite.otel module auto-initializes when OTEL is enabled"""
+        # Module initialization happens on import when MITE_CONF_OTEL_ENABLED=true
+        # Since we set this at the top of the test file, tracing should be initialized
+        from mite.otel.tracing import _state
+
+        # After module import with OTEL enabled, tracer should be initialized
+        assert _state.tracer is not None
+
+
+class TestInjectHeaders:
+    """Tests for inject_headers function"""
+
+    def test_inject_headers_adds_trace_context(self):
+        """Test that inject_headers adds W3C trace context headers"""
+        from mite.otel.context import inject_headers
+
+        headers = {"Content-Type": "application/json"}
+
+        with patch("mite.otel.context.inject") as mock_inject:
+            with patch("mite.otel.context._is_enabled", return_value=True):
+                inject_headers(headers)
+                mock_inject.assert_called_once()
+
+    def test_inject_headers_when_disabled(self):
+        """Test that inject_headers is a no-op when disabled"""
+        from mite.otel.context import inject_headers
+
+        headers = {"Content-Type": "application/json"}
+
+        with patch("mite.otel.context._is_enabled", return_value=False):
+            result = inject_headers(headers)
+            assert result == headers  # Unchanged
+            assert "traceparent" not in result
+
+
+class TestSelectiveInstrumentation:
+    """Tests for mixing traced and untraced journeys"""
+
+    @pytest.mark.asyncio
+    async def test_mixed_traced_and_untraced_journeys(self, httpserver):
+        """Test that traced and untraced journeys can coexist"""
+        from mite.otel import mite_http_traced
+        from mite.otel.tracing import get_tracer
+        from mite_http import mite_http  # noqa: F401
+
+        httpserver.expect_request("/traced", "GET").respond_with_data("traced")
+        httpserver.expect_request("/untraced", "GET").respond_with_data("untraced")
+
+        context = MockContext()
+        tracer = get_tracer()
+        mock_span = MagicMock()
+        mock_span.__enter__ = Mock(return_value=mock_span)
+        mock_span.__exit__ = Mock(return_value=False)
+
+        @mite_http_traced
+        async def traced_journey(ctx):
+            await ctx.http.get(httpserver.url_for("/traced"))
+
+        @mite_http
+        async def untraced_journey(ctx):
+            await ctx.http.get(httpserver.url_for("/untraced"))
+
+        # Traced journey should create spans (journey + HTTP)
+        with patch.object(
+            tracer, "start_as_current_span", return_value=mock_span
+        ) as mock_start:
+            await traced_journey(context)
+            # Should create journey span + HTTP span
+            assert mock_start.call_count >= 2
+
+        # Untraced journey should create NO spans at all
+        with patch.object(
+            tracer, "start_as_current_span", return_value=mock_span
+        ) as mock_start:
+            await untraced_journey(context)
+            # No spans created for untraced journeys
+            assert mock_start.call_count == 0
+
+        # Both requests should have completed
+        assert len(httpserver.log) == 2
+
+    @pytest.mark.asyncio
+    async def test_untraced_journey_with_transaction(self, httpserver):
+        """Test that @mite_http journeys don't create transaction spans"""
+        from mite.context import Context
+        from mite.otel.tracing import get_tracer
+        from mite_http import mite_http
+
+        httpserver.expect_oneshot_request("/test", "GET").respond_with_data("ok")
+
+        send_fn = Mock()
+        context = Context(send_fn, {})
+        tracer = get_tracer()
+        mock_span = MagicMock()
+        mock_span.__enter__ = Mock(return_value=mock_span)
+        mock_span.__exit__ = Mock(return_value=False)
+
+        @mite_http
+        async def untraced_journey(ctx):
+            async with ctx.transaction("Should Not Trace"):
+                await ctx.http.get(httpserver.url_for("/test"))
+
+        # Untraced journey should create NO spans
+        with patch.object(
+            tracer, "start_as_current_span", return_value=mock_span
+        ) as mock_start:
+            await untraced_journey(context)
+            # No spans created
+            assert mock_start.call_count == 0
+
+        # HTTP request should have completed
+        assert len(httpserver.log) == 1
+        # Transaction message sent (non-tracing)
+        assert send_fn.call_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_context_variable_isolation(self, httpserver):
+        """Test that context variable properly isolates traced/untraced journeys"""
+        from mite.otel import mite_http_traced
+        from mite.otel.instrumentation import is_in_traced_journey
+        from mite_http import mite_http
+
+        httpserver.expect_request("/traced", "GET").respond_with_data("traced")
+        httpserver.expect_request("/untraced", "GET").respond_with_data("untraced")
+
+        context = MockContext()
+
+        # Track context state during execution
+        traced_states = []
+        untraced_states = []
+
+        @mite_http_traced
+        async def traced_journey(ctx):
+            traced_states.append(is_in_traced_journey())
+            await ctx.http.get(httpserver.url_for("/traced"))
+
+        @mite_http
+        async def untraced_journey(ctx):
+            untraced_states.append(is_in_traced_journey())
+            await ctx.http.get(httpserver.url_for("/untraced"))
+
+        # Initially not in traced journey
+        assert not is_in_traced_journey()
+
+        # Execute traced journey
+        await traced_journey(context)
+        assert traced_states == [True]  # Inside traced journey
+
+        # Context should be reset after traced journey
+        assert not is_in_traced_journey()
+
+        # Execute untraced journey
+        await untraced_journey(context)
+        assert untraced_states == [False]  # Not in traced journey
+
+        # Should remain unset
+        assert not is_in_traced_journey()
+
+        # Both requests completed
+        assert len(httpserver.log) == 2
+
+
+class TestImportOrderIndependence:
+    """Tests verifying import order doesn't matter"""
+
+    @pytest.mark.asyncio
+    async def test_import_traced_before_mite_http(self, httpserver):
+        """Test importing mite_http_traced before mite_http module"""
+        # This should work regardless of import order
+        from mite.otel import mite_http_traced
+
+        httpserver.expect_oneshot_request("/test", "GET").respond_with_data("ok")
+        context = MockContext()
+
+        @mite_http_traced
+        async def journey(ctx):
+            await ctx.http.get(httpserver.url_for("/test"))
+
+        await journey(context)
+        assert len(httpserver.log) == 1
+
+    @pytest.mark.asyncio
+    async def test_import_mite_http_before_traced(self, httpserver):
+        """Test importing mite_http before mite_http_traced"""
+        # Already imported in this file, but test still works
+        from mite.otel import mite_http_traced
+        from mite_http import mite_http  # noqa: F401
+
+        httpserver.expect_oneshot_request("/test", "GET").respond_with_data("ok")
+        context = MockContext()
+
+        @mite_http_traced
+        async def journey(ctx):
+            await ctx.http.get(httpserver.url_for("/test"))
+
+        await journey(context)
+        assert len(httpserver.log) == 1
+
+
+class TestDecoratorEventLoopMemoization:
+    """Tests for event loop memoization in decorated functions"""
+
+    @pytest.mark.asyncio
+    async def test_mite_http_traced_eventloop_memoization(self):
+        """Test that @mite_http_traced works with event loop memoization"""
+        from mite.otel import mite_http_traced
+        from mite_http import SessionPool
+
+        @mite_http_traced
+        async def foo(ctx):
+            pass
+
+        await foo(MockContext())
+
+        # Verify session pool was memoized for current event loop
+        assert asyncio.get_running_loop() in SessionPool._session_pools


### PR DESCRIPTION
#### What is the change?

This pull request introduces comprehensive OpenTelemetry tracing support to the `mite` framework, enabling distributed tracing, metrics, and hierarchical span creation with minimal code changes. The integration is highly configurable via environment variables and supports multiple exporters such as console, OTLP, Jaeger, and Zipkin. Instrumentation is automatic for journeys, transactions, and HTTP requests, but also supports manual span creation for advanced use cases.

Key changes include:

**Documentation and Configuration**

* Added a detailed `OpenTelemetry.md` guide covering features, setup, configuration, usage examples, and best practices for tracing in `mite`.
* Introduced `mite/otel/config.py` to centralize reading and parsing of OpenTelemetry-related environment variables for flexible configuration.

**Core Tracing and Instrumentation**

* Created `mite/otel/__init__.py` to manage initialization and auto-patching of tracing hooks based on configuration, exposing utilities for manual control and safe fallbacks if OpenTelemetry is not installed.
* Implemented core tracing utilities in `mite/otel/instrumentation.py`, providing decorators and context managers (`trace_journey`, `trace_transaction`) for manual and automatic span creation.

**Automatic Instrumentation Hooks**

* Added patch modules for seamless tracing:
  - [`mite/otel/mite_http_integration.py`](diffhunk://#diff-55ec5d4edbf64c91596dc3316a84228b0fe0cec472baedbb14d89d9630360becR1-R57): Automatically wraps the `@mite_http` decorator to create journey spans.
  - [`mite/otel/context_integration.py`](diffhunk://#diff-daa94153e3a17cbe042d877045d6b17b55b9b6701cf18fc0c1400d25735908afR1-R53): Patches the `Context.transaction` method to create transaction spans and propagate errors.
  - [`mite/otel/acurl_integration.py`](diffhunk://#diff-24853c9648bdaf2f84649f9ddb68dde845708529aee7e4b3b5aa98e476d20778R1-R151): Patches HTTP client methods to create HTTP spans, inject trace headers, and record detailed request/response metadata.

**Context Propagation**

* Added `mite/otel/context.py` to support injecting trace context into outgoing HTTP headers for distributed tracing.

#### Does this change require a version increment:

- [ ] Major
- [x] Minor
- [ ] Patch
