### PR TITLE
Cython 3x migration

### DIFF
--- a/CYTHON3_SEGFAULT_ROOT_CAUSE_ANALYSIS.md
+++ b/CYTHON3_SEGFAULT_ROOT_CAUSE_ANALYSIS.md
@@ -1,6 +1,4 @@
-# Python 3.12 + Cython 3 Upgrade Notes
-
-**Note:** This upgrade keeps uvloop pinned at ==0.21.0. To upgrade uvloop in the future, we'll need to replace deprecated `asyncio.get_event_loop()` calls in `mite/__main__.py` and `mite/zmq.py` with `asyncio.new_event_loop()` or `asyncio.get_running_loop()` as appropriate.
+# Cython 3 Upgrade Notes
 
 ## Why the Previous Attempt Failed (Sept 2024, commit 266efeb)
 
@@ -62,42 +60,3 @@ wrapper.loop.add_reader(sock, wrapper.curl_perform_read, sock)  # correct
 
 - Removed extra `wrapper` argument from all `add_reader()`, `add_writer()`, `call_soon()`, and `call_later()` calls
 - This was the critical bug that caused crashes during testing
-
-### 4. Update version constraints
-
-**Why:** Allow Cython 3 and Python 3.12 while maintaining backward compatibility.
-
-**Changed files:**
-
-- `acurl/pyproject.toml` and `pyproject.toml`:
-  - Cython: `<3.0` → `>=3.0` (enable Cython 3)
-  - Python: `<3.12` → `<3.13` (enable Python 3.12)
-  - uvloop: kept at `==0.21.0` (newer versions require event loop API changes)
-  - Added Python 3.12 classifier
-  
-### 5. Update test matrix
-
-**Why:** Ensure CI tests Python 3.12 compatibility.
-
-**Changed file:** `pyproject.toml`
-
-- Added "3.12" to hatch test matrix
-
-## Testing Results
-
-Tested with both Python 3.11.9 and 3.12.3 using Cython 3.2.1:
-
-- ✅ Basic HTTP requests work
-- ✅ 100+ concurrent requests work  
-- ✅ Full mite framework (runner + controller) works
-- ✅ 500+ requests with mite_http journey - no segfaults
-- ✅ Backward compatible with Python 3.11
-
-## Files Modified
-
-1. `acurl/src/acurl.pyx` - Added `noexcept`, fixed callback arguments
-2. `acurl/src/session.pyx` - Added `noexcept` to callbacks
-3. `acurl/setup.py` - Added `language_level: 3`
-4. `acurl/pyproject.toml` - Updated Cython/Python/uvloop versions
-5. `pyproject.toml` - Updated Cython/Python/uvloop versions, added Python 3.12 to test matrix
-

--- a/CYTHON3_SEGFAULT_ROOT_CAUSE_ANALYSIS.md
+++ b/CYTHON3_SEGFAULT_ROOT_CAUSE_ANALYSIS.md
@@ -1,0 +1,103 @@
+# Python 3.12 + Cython 3 Upgrade Notes
+
+**Note:** This upgrade keeps uvloop pinned at ==0.21.0. To upgrade uvloop in the future, we'll need to replace deprecated `asyncio.get_event_loop()` calls in `mite/__main__.py` and `mite/zmq.py` with `asyncio.new_event_loop()` or `asyncio.get_running_loop()` as appropriate.
+
+## Why the Previous Attempt Failed (Sept 2024, commit 266efeb)
+
+Tried adding lambda wrappers around asyncio callbacks:
+
+```python
+wrapper.loop.add_reader(sock, lambda *args: wrapper.curl_perform_read(sock))
+```
+
+This caused segfaults because lambda closures don't maintain proper references to Cython objects. The wrapper gets freed before the lambda executes.
+
+## What Actually Works
+
+The master branch code already handles callbacks correctly - just pass bound methods directly:
+
+```python
+wrapper.loop.add_reader(sock, wrapper.curl_perform_read, sock)
+```
+
+But I had to fix one issue: don't pass `self` as an extra argument when using bound methods. Changed:
+
+```python
+wrapper.loop.add_reader(sock, wrapper.curl_perform_read, wrapper, sock)  # wrong
+```
+
+to:
+
+```python
+wrapper.loop.add_reader(sock, wrapper.curl_perform_read, sock)  # correct
+```
+
+## Required Changes and Why
+
+### 1. Add `noexcept` to C callbacks (Cython 3 requirement)
+
+**Why:** Cython 3 requires explicit declaration that C callback functions won't raise Python exceptions. Without `noexcept`, the compiler can't guarantee exception safety when C code calls back into our Cython code.
+
+**Changed files:**
+
+- `acurl/src/acurl.pyx`: Added `noexcept` to `handle_socket()` and `start_timeout()`
+  - These are registered as libcurl callbacks (CURLMOPT_SOCKETFUNCTION, CURLMOPT_TIMERFUNCTION)
+  - They're called from C code, so they must not propagate Python exceptions
+  
+- `acurl/src/session.pyx`: Added `noexcept` to `header_callback()` and `body_callback()`
+  - These are registered as CURLOPT_HEADERFUNCTION and CURLOPT_WRITEFUNCTION
+  - Called by libcurl during HTTP response processing
+
+### 2. Add `language_level: 3` compiler directive
+
+**Why:** Cython 3 changed the default language level. We need to explicitly specify Python 3 semantics to ensure consistent behavior (string types, division operator, print function, etc.).
+
+**Changed file:** `acurl/setup.py`
+
+### 3. Fix asyncio callback argument passing
+
+**Why:** Bound methods (like `wrapper.curl_perform_read`) already include `self`. Passing it again causes `TypeError: wrap() takes exactly 1 positional argument (2 given)`.
+
+**Changed file:** `acurl/src/acurl.pyx`
+
+- Removed extra `wrapper` argument from all `add_reader()`, `add_writer()`, `call_soon()`, and `call_later()` calls
+- This was the critical bug that caused crashes during testing
+
+### 4. Update version constraints
+
+**Why:** Allow Cython 3 and Python 3.12 while maintaining backward compatibility.
+
+**Changed files:**
+
+- `acurl/pyproject.toml` and `pyproject.toml`:
+  - Cython: `<3.0` → `>=3.0` (enable Cython 3)
+  - Python: `<3.12` → `<3.13` (enable Python 3.12)
+  - uvloop: kept at `==0.21.0` (newer versions require event loop API changes)
+  - Added Python 3.12 classifier
+  
+### 5. Update test matrix
+
+**Why:** Ensure CI tests Python 3.12 compatibility.
+
+**Changed file:** `pyproject.toml`
+
+- Added "3.12" to hatch test matrix
+
+## Testing Results
+
+Tested with both Python 3.11.9 and 3.12.3 using Cython 3.2.1:
+
+- ✅ Basic HTTP requests work
+- ✅ 100+ concurrent requests work  
+- ✅ Full mite framework (runner + controller) works
+- ✅ 500+ requests with mite_http journey - no segfaults
+- ✅ Backward compatible with Python 3.11
+
+## Files Modified
+
+1. `acurl/src/acurl.pyx` - Added `noexcept`, fixed callback arguments
+2. `acurl/src/session.pyx` - Added `noexcept` to callbacks
+3. `acurl/setup.py` - Added `language_level: 3`
+4. `acurl/pyproject.toml` - Updated Cython/Python/uvloop versions
+5. `pyproject.toml` - Updated Cython/Python/uvloop versions, added Python 3.12 to test matrix
+

--- a/acurl/pyproject.toml
+++ b/acurl/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "acurl"
-version = "1.1.0"
+version = "1.2.0"
 description = "An async Curl library."
 readme = "README.md"
 license = "MIT"

--- a/acurl/pyproject.toml
+++ b/acurl/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "wheel", "Cython<3.0"]
+requires = ["setuptools", "wheel", "Cython>=3.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "ujson>=4.1.0",
@@ -35,7 +36,7 @@ dev = [
     "pytest-cov",
     "pytest-httpbin",
     "ruff>=0.1.0",
-    "Cython<3.0",
+    "Cython>=3.0",
 ]
 
 [project.urls]

--- a/acurl/pyproject.toml
+++ b/acurl/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.1.0"
 description = "An async Curl library."
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.15"
 authors = [
     {name = "Sky UK", email = "mite@sky.uk"},
 ]

--- a/acurl/pyproject.toml
+++ b/acurl/pyproject.toml
@@ -8,7 +8,7 @@ version = "1.2.0"
 description = "An async Curl library."
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10,<3.14"
 authors = [
     {name = "Sky UK", email = "mite@sky.uk"},
 ]

--- a/acurl/setup.py
+++ b/acurl/setup.py
@@ -22,6 +22,7 @@ setup(
         extensions,
         gdb_debug=True,
         compiler_directives={
+            "language_level": 3,
             "warn.undeclared": True,
             "warn.unreachable": True,
             "warn.maybe_uninitialized": True,

--- a/acurl/src/acurl.pyx
+++ b/acurl/src/acurl.pyx
@@ -21,19 +21,19 @@ class AcurlError(Exception):
 # with the python asyncio library we need to call back into python.  So these
 # functions do take the GIL, as indicated by `with gil` in their signatures.
 # The performance impact of this is yet tbd.
-cdef int handle_socket(CURL *easy, curl_socket_t sock, int action, void *userp, void *socketp) with gil:
+cdef int handle_socket(CURL *easy, curl_socket_t sock, int action, void *userp, void *socketp) noexcept with gil:
     cdef CurlWrapper wrapper = <CurlWrapper>userp
     if action == CURL_POLL_IN or action == CURL_POLL_INOUT:
-        wrapper.loop.add_reader(sock, wrapper.curl_perform_read, wrapper, sock)
+        wrapper.loop.add_reader(sock, wrapper.curl_perform_read, sock)
     if action == CURL_POLL_OUT or action == CURL_POLL_INOUT:
-        wrapper.loop.add_writer(sock, wrapper.curl_perform_write, wrapper, sock)
+        wrapper.loop.add_writer(sock, wrapper.curl_perform_write, sock)
     if action == CURL_POLL_REMOVE:
         wrapper.loop.remove_reader(sock)
         wrapper.loop.remove_writer(sock)
     if action != CURL_POLL_IN and action != CURL_POLL_OUT and action != CURL_POLL_INOUT and action != CURL_POLL_REMOVE:
         raise Exception("oops")
 
-cdef int start_timeout(CURLM *multi, long timeout_ms, void *userp) with gil:
+cdef int start_timeout(CURLM *multi, long timeout_ms, void *userp) noexcept with gil:
     cdef CurlWrapper wrapper = <CurlWrapper>userp
     cdef int _running
     cdef double secs
@@ -42,10 +42,10 @@ cdef int start_timeout(CURLM *multi, long timeout_ms, void *userp) with gil:
             wrapper.timer_handle.cancel()
             wrapper.timer_handle = None
     elif timeout_ms == 0:
-        wrapper.loop.call_soon(wrapper.timeout_expired, wrapper)
+        wrapper.loop.call_soon(wrapper.timeout_expired)
     else:
         secs = timeout_ms / 1000
-        wrapper.timer_handle = wrapper.loop.call_later(secs, wrapper.timeout_expired, wrapper)
+        wrapper.timer_handle = wrapper.loop.call_later(secs, wrapper.timeout_expired)
 
 cdef class CurlWrapper:
     cdef CURLM* multi

--- a/acurl/src/session.pyx
+++ b/acurl/src/session.pyx
@@ -32,7 +32,7 @@ cdef BufferNode* alloc_buffer_node(size_t size, char *data):
     node.next = NULL
     return node
 
-cdef size_t header_callback(char *ptr, size_t size, size_t nmemb, void *userdata):
+cdef size_t header_callback(char *ptr, size_t size, size_t nmemb, void *userdata) noexcept:
     cdef _Response response = <_Response>userdata
     cdef BufferNode* node = alloc_buffer_node(size * nmemb, ptr)
     if response.header_buffer == NULL:  # FIXME: unlikely
@@ -42,7 +42,7 @@ cdef size_t header_callback(char *ptr, size_t size, size_t nmemb, void *userdata
     response.header_buffer_tail = node
     return node.len
 
-cdef size_t body_callback(char *ptr, size_t size, size_t nmemb, void *userdata):
+cdef size_t body_callback(char *ptr, size_t size, size_t nmemb, void *userdata) noexcept:
     cdef _Response response = <_Response>userdata
     cdef BufferNode* node = alloc_buffer_node(size * nmemb, ptr)
     if response.body_buffer == NULL:  # FIXME: unlikely

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "A Python Performance Testing Framework"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10,<3.14"
 authors = [
     {name = "Sky UK", email = "mite@sky.uk"},
 ]
@@ -127,7 +127,7 @@ cov-report = "python -m webbrowser coverage_html_report/index.html"
 acurl-test = "pytest {args:acurl/tests/}"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.10", "3.11", "3.12"]
+python = ["3.10", "3.11", "3.12", "3.13"]
 
 
 [tool.hatch.envs.perf-test]
@@ -147,8 +147,7 @@ MITE_PERFTEST_OUT = "output"
 perf-test = "python test/perf/perftest.py {args:}"
 
 [[tool.hatch.envs.perf-test.matrix]]
-python = ["3.11"] # Extend to 3.10 as we should support this.
-
+python = ["3.10", "3.11", "3.12", "3.13"]
 
 
 [tool.hatch.envs.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "A Python Performance Testing Framework"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.10,<3.12"
+requires-python = ">=3.10,<3.13"
 authors = [
     {name = "Sky UK", email = "mite@sky.uk"},
 ]
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Operating System :: POSIX :: Linux",
 ]
 # Core dependencies for the base mite framework (runner, controller, messaging, CLI)
@@ -28,7 +29,7 @@ dependencies = [
     "prettytable",
     "pyzmq",
     "ujson",
-    "uvloop",
+    "uvloop==0.21.0",
 ]
 
 [project.optional-dependencies]
@@ -102,7 +103,7 @@ dev = [
     "hypothesis", # used in finagle/thrift tests
     "werkzeug==3.1.3",
     "httpbin>=0.10.2", # Required for werkzeug 3.x compatibility
-    "Cython<3.0", # required for coverage plugin and acurl
+    "Cython>=3.0", # required for coverage plugin and acurl
 ]
 
 [project.urls]
@@ -165,7 +166,7 @@ acurl-test = "pytest {args:acurl/tests/}"
 
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.10", "3.11"]
+python = ["3.10", "3.11", "3.12"]
 
 
 [tool.hatch.envs.perf-test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "A Python Performance Testing Framework"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.15"
 authors = [
     {name = "Sky UK", email = "mite@sky.uk"},
 ]


### PR DESCRIPTION
#### What is the change?

Continuation of the previous work https://github.com/sky-uk/mite/pull/301

**Compatibility and Versioning Updates**
* Updated Cython dependency from `<3.0` to `>=3.0` and Python version support to `<3.14` in both `acurl/pyproject.toml` and `pyproject.toml`. Tested with `python:3.14.1-slim` image, but some dependencies do not support it yet.

**Cython 3 Migration Fixes**
* Added `noexcept` to all C callback functions in `acurl/src/acurl.pyx` and `acurl/src/session.pyx` to comply with Cython 3's requirements for exception safety in C callbacks.
* Set the `language_level: 3` compiler directive in `acurl/setup.py`.

**Critical Bug Fixes**
* Fixed asyncio callback argument handling in `acurl/src/acurl.pyx` by removing redundant `self` arguments when passing bound methods. This resolves segfaults and `TypeError` exceptions during high concurrency.

#### Does this change require a version increment:

- [ ] Major
- [x] Minor
- [ ] Patch
