### PR TITLE
update dockerfile base image and remove setup.cfg caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,11 @@
 # this stops the requirement for rust be dragged in (causing much "fun" in so far as the image size bloats
 # to approx 2Gb!)
 
-FROM python:3.11.13-alpine3.22
+FROM python:3.12.13-alpine3.24
 
 # py3-cryptography is added here as a means to get python cryptography onto the image (prebuilt) and without
 # need to install rust compiler
 RUN apk add --no-cache gnupg libressl tar ca-certificates gcc cmake make libc-dev coreutils g++ libzmq zeromq zeromq-dev git curl-dev libffi libffi-dev libbz2 bzip2-dev xz-dev libjpeg jpeg-dev py3-cryptography
-
-# This little bit of magic caches the dependencies in a docker layer, so that
-# rebuilds locally are not so expensive 
-COPY acurl/setup.cfg /acurl-setup.cfg
-COPY setup.cfg /mite-setup.cfg
-
-RUN python3 -c "import configparser; c = configparser.ConfigParser(); c.read('/mite-setup.cfg'); print(c['options']['install_requires'])" | grep -v acurl | xargs pip install
-
-RUN python3 -c "import configparser; c = configparser.ConfigParser(); c.read('/acurl-setup.cfg'); print(c['options']['install_requires'])" | xargs pip install
 
 ADD . / /mite/
 


### PR DESCRIPTION
#### What is the change?
Update Dockerfile to remove the setup.cfg based caching as it is removed after moving to hatch based install and update base image from python:3.11.13-alpine3.22 to python:3.12.13-alpine3.24 to overcome this [ciritical vulnerabilities](https://hub.docker.com/layers/library/python/3.11.13-alpine3.22/images/sha256-6849ab1bde2e04f50c866a51c7f794b4388d1c7dcaee84470c4d67544dec8806)
#### Does this change require a version increment:

- [ ] Major
- [ ] Minor
- [x] Patch
