### PR TITLE
acurl: fix response refcount leak, buffer truncation, and interim 1xx header parsing

### DIFF
--- a/acurl/pyproject.toml
+++ b/acurl/pyproject.toml
@@ -36,6 +36,9 @@ dev = [
     "pytest-asyncio",
     "pytest-cov",
     "pytest-httpbin",
+    "werkzeug==3.1.3",
+    "httpbin>=0.10.2", 
+    "pytest-httpserver",
     "ruff>=0.1.0",
     "Cython>=3.0",
 ]

--- a/acurl/pyproject.toml
+++ b/acurl/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "acurl"
-version = "1.2.1"
+version = "1.3.0"
 description = "An async Curl library."
 readme = "README.md"
 license = "MIT"
@@ -36,7 +36,7 @@ dev = [
     "pytest-asyncio",
     "pytest-cov",
     "pytest-httpbin",
-    "werkzeug==3.1.3",
+    "werkzeug>=3.1.3",
     "httpbin>=0.10.2", 
     "pytest-httpserver",
     "ruff>=0.1.0",

--- a/acurl/src/acurl.pyx
+++ b/acurl/src/acurl.pyx
@@ -96,14 +96,16 @@ cdef class CurlWrapper:
                 easy = message.easy_handle
                 acurl_easy_getinfo_voidptr(easy, CURLINFO_PRIVATE, &response_raw)
                 response = <_Response>response_raw
-                if message.data.result == CURLE_OK:
-                    response.future.set_result(response)
-                else:
-                    response.future.set_exception(AcurlError(f"curl failed with code {message.data.result} {curl_easy_strerror(message.data.result).decode('utf-8')}"))
-
-                curl_multi_remove_handle(self.multi, easy)
-            else:
-                raise Exception("oops2")
+                if not response.future.done():
+                    if message.data.result == CURLE_OK:
+                        response.future.set_result(response)
+                    else:
+                        response.future.set_exception(AcurlError(f"curl failed with code {message.data.result} {curl_easy_strerror(message.data.result).decode('utf-8')}"))
+                try:
+                    curl_multi_remove_handle(self.multi, easy)
+                finally:
+                    # pairs with Py_INCREF in _inner_request(session.pyx); curl is done with the handle here
+                    Py_DECREF(response)
             message = curl_multi_info_read(self.multi, &_pending)
 
     def session(self):

--- a/acurl/src/response.pyx
+++ b/acurl/src/response.pyx
@@ -243,9 +243,20 @@ cdef class _Response:
     def _get_header_lines(self):
         cdef list headers = self.header.split("\r\n")
         headers = headers[:-2]  # drop the final blank lines
-        while headers[0].startswith("HTTP/1.1 100"):
-            headers = headers[2:]
-        return headers[1:]  # drop the final response code
+        # libcurl feeds the header callback one block per response, including
+        # interim 1xx ones (100 Continue, 103 Early Hints), all concatenated
+        # into a single buffer.  The last status line is by definition the
+        # final response's, so everything after it is the real header set.
+        # Scanning backwards avoids having to know how many interim blocks
+        # there are or how long each one is -- 103 carries headers, 100 does
+        # not.  Safe because redirects are followed manually with a fresh
+        # handle per hop (see Session._outer_request), so one buffer never
+        # holds two final responses.
+        cdef Py_ssize_t i
+        for i in range(len(headers) - 1, -1, -1):
+            if headers[i].startswith("HTTP/"):
+                return headers[i + 1:]  # drop the final status line
+        return headers
 
     # TODO: is this part of the request api?
     @property

--- a/acurl/src/session.pyx
+++ b/acurl/src/session.pyx
@@ -1,7 +1,7 @@
 #cython: language_level=3
 
 from libc.stdlib cimport malloc
-from libc.string cimport strndup
+from libc.string cimport memcpy 
 from cpython.pycapsule cimport PyCapsule_New, PyCapsule_GetPointer
 from curlinterface cimport *
 from cpython.ref cimport Py_INCREF
@@ -18,7 +18,11 @@ class RequestError(Exception):
 cdef BufferNode* alloc_buffer_node(size_t size, char *data):
     cdef BufferNode* node = <BufferNode*>malloc(sizeof(BufferNode))
     if node == NULL:
-        printf("OOOPS!!!!")  # FIXME: better checks
+        return NULL;
+    node.buffer = <char*>malloc(size)
+    if size > 0 and node.buffer == NULL:
+        free(node)  # don't leak the node struct we just allocated
+        return NULL
     node.len = size
     # FIXME: the curl docs give an example function that uses realloc on a
     # single buffer rather than a linked list.  Possibly that method would be
@@ -28,13 +32,15 @@ cdef BufferNode* alloc_buffer_node(size_t size, char *data):
     # response data).  It would also make the code less complicated.  Worth
     # benchmarking the effects someday...
     # <https://curl.se/libcurl/c/CURLOPT_WRITEFUNCTION.html>
-    node.buffer = strndup(data, size)
+    memcpy(node.buffer, data, size)
     node.next = NULL
     return node
 
 cdef size_t header_callback(char *ptr, size_t size, size_t nmemb, void *userdata) noexcept:
     cdef _Response response = <_Response>userdata
     cdef BufferNode* node = alloc_buffer_node(size * nmemb, ptr)
+    if node == NULL:
+        return 0  # signals libcurl to abort; surfaces as AcurlError via check_multi_info()
     if response.header_buffer == NULL:  # FIXME: unlikely
         response.header_buffer = node
     if response.header_buffer_tail != NULL:  # FIXME: likely
@@ -45,6 +51,8 @@ cdef size_t header_callback(char *ptr, size_t size, size_t nmemb, void *userdata
 cdef size_t body_callback(char *ptr, size_t size, size_t nmemb, void *userdata) noexcept:
     cdef _Response response = <_Response>userdata
     cdef BufferNode* node = alloc_buffer_node(size * nmemb, ptr)
+    if node == NULL:
+        return 0  # signals libcurl to abort; surfaces as AcurlError via check_multi_info()
     if response.body_buffer == NULL:  # FIXME: unlikely
         response.body_buffer = node
     if response.body_buffer_tail != NULL:  # FIXME: likely
@@ -158,20 +166,7 @@ cdef class Session:
         acurl_easy_setopt_voidptr(curl, CURLOPT_WRITEDATA, <void*>response)
         acurl_easy_setopt_writecb(curl, CURLOPT_HEADERFUNCTION, header_callback)
         acurl_easy_setopt_voidptr(curl, CURLOPT_HEADERDATA, <void*>response)
-
-        # We need to increment the reference count on the response.  To
-        # python's eyes the last reference to it disappears when we exit this
-        # function (and thus it would get collected) -- but the curl event
-        # loop has a reference to it so it needs to remain alive.  FIXME:
-        # where does it get decrefed?  In principle we need a matching
-        # Py_DECREF somewhere in the code.  But there's malignant
-        # counter-wizardry coming from cython -- when we coerce the pointer
-        # out of curl, it gets assigned into a python variable, which cython
-        # will "helpfully" decref for us when it goes out of scope -- so the
-        # decref might already be handled for us (we do prevent the magic
-        # decref in some circumstances, though).  This is not really an
-        # optimal situation and we need to get to the bottom of it...  (Is it
-        # related to the no_gc_clear and the crashes that it now prevents?)
+        # pair with Py_DECREF in check_multi_info (acurl.pyx) ; curl holds a raw ref via CURLOPT_PRIVATE
         Py_INCREF(response)
 
         if auth is not None:
@@ -258,12 +253,6 @@ cdef class Session:
             data,
             cert,
         )
-        # This decref is the partner to the incref in _inner_request above --
-        # at this point curl is done with the response and so we no longer
-        # need to keep its refcount incremented to prevent the GC from
-        # cleaning it up when the only reference to it is held by curl and not
-        # python.
-        Py_DECREF(response)
         cdef _Response old_response
         if self.response_callback:
             # FIXME: should this be async?

--- a/acurl/tests/test_response.py
+++ b/acurl/tests/test_response.py
@@ -1,6 +1,32 @@
+import asyncio
 import pytest
 from werkzeug.datastructures import Headers
 from werkzeug.wrappers import Response
+
+
+@pytest.fixture
+async def raw_response_server():
+    """Serve a canned byte blob, so tests can exercise wire-level responses
+    (interim 1xx blocks) that werkzeug's dev server cannot produce."""
+    servers = []
+
+    async def serve(payload):
+        async def handle(reader, writer):
+            await reader.readuntil(b"\r\n\r\n")  # consume the request
+            writer.write(payload)
+            await writer.drain()
+            writer.close()
+
+        server = await asyncio.start_server(handle, "127.0.0.1", 0)
+        servers.append(server)
+        host, port = server.sockets[0].getsockname()[:2]
+        return f"http://{host}:{port}/"
+
+    yield serve
+
+    for server in servers:
+        server.close()
+        await server.wait_closed()
 
 
 @pytest.mark.asyncio
@@ -21,14 +47,6 @@ async def test_response_headers(httpserver, acurl_session):
     assert r.headers["baz"] == "quux, quuz"
 
 
-async def connected_cb(body, reader, writer):
-    writer.write(body)
-    await writer.drain()
-    writer.close()
-    await writer.wait_closed()
-    await reader.read(-1)
-
-
 @pytest.mark.asyncio
 async def test_response_headers_with_HTTP_100(httpserver, acurl_session):
     hdrs = Headers()
@@ -42,6 +60,31 @@ async def test_response_headers_with_HTTP_100(httpserver, acurl_session):
 
     assert "Foo" in r.headers
     assert r.headers["Foo"] == "bar"
+
+
+EARLY_HINTS_RESPONSE = (
+    b"HTTP/1.1 103 Early Hints\r\n"
+    b"link: </style.css>; rel=preload; as=style\r\n"
+    b"\r\n"
+    b"HTTP/1.1 200 OK\r\n"
+    b"Foo: bar\r\n"
+    b"Content-Length: 2\r\n"
+    b"\r\n"
+    b"hi"
+)
+
+
+@pytest.mark.asyncio
+async def test_response_headers_with_HTTP_103(raw_response_server, acurl_session):
+    url = await raw_response_server(EARLY_HINTS_RESPONSE)
+    r = await acurl_session.get(url)
+
+    assert r.status_code == 200
+    assert r.body == b"hi"
+    assert r.headers["Foo"] == "bar"
+    assert r.headers["Content-Length"] == "2"
+    # headers from the interim block must not leak into the final response
+    assert "link" not in r.headers
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What is the change?

Memory-safety and correctness fixes inside acurl

### Reference leak on the response object
`_inner_request` (`session.pyx`) increfs the `_Response` so it survives while
curl holds a raw pointer to it via `CURLOPT_PRIVATE`. The matching `Py_DECREF`
sat at the bottom of `_outer_request`, only reached on the happy path. Every
redirect hop and every error path leaked a reference, and with it the
response's curl handle and buffers.

The decref moves into `check_multi_info` (`acurl.pyx`), in a `try/finally`
around `curl_multi_remove_handle`, so it runs exactly once per transfer
whatever the outcome. Confirmed against the generated C that the
`<_Response>response_raw` cast is a borrowed reference with its own balanced
INCREF/XDECREF from Cython, so this decref releases curl's reference and
nothing else.

Two smaller changes in the same block:
- `set_result`/`set_exception` are guarded by `if not response.future.done()`;
  a cancelled future previously raised `InvalidStateError` out of the curl
  event-loop callback.
- Dropped `else: raise Exception("oops2")` for non-`CURLMSG_DONE` messages.
  `CURLMSG_DONE` is the only value libcurl defines, and raising from inside
  the socket-action callback is worse than ignoring it.

### Truncated response buffers
`alloc_buffer_node` used `strndup`, which stops at the first NULL. Any binary
body or header containing a NUL was silently truncated. Now `malloc` +
`memcpy` using the length curl reports. The `node == NULL` case was a
`printf("OOOPS!!!!")` followed by a write through the NULL pointer; both
allocations are now checked, and on failure the callbacks return `0`, which
aborts the transfer and surfaces as an `AcurlError` on the future.

### Interim 1xx responses and non-1.1 HTTP versions
libcurl concatenates every response block for a transfer into one header
buffer, interim ones included. `_get_header_lines` only skipped a literal
`HTTP/1.1 100`, so `103 Early Hints` leaked its `link:` headers into the final
response (unlike 100, a 103 block carries headers), and HTTP/2 and HTTP/3
status lines were not matched at all.

It now scans backwards for the last status line and returns everything after
it, which is correct regardless of how many interim blocks there are. It's safe because
`CURLOPT_FOLLOWLOCATION` is never set. Redirects are followed manually with a
fresh handle per hop, so one buffer never holds two final responses.

Added `test_response_headers_with_HTTP_103` plus a raw-socket fixture, since
werkzeug's dev server cannot emit interim blocks.

### Dev dependencies
Added `werkzeug`, `httpbin` and `pytest-httpserver` to the `dev` extra. These
were previously only available transitively via `pytest-httpbin`, so a clean
install could not run the test suite.

#### Does this change require a version increment:

- [ ] Major
- [x] Minor
- [ ] Patch
